### PR TITLE
chore: update package.json with the correct GitHub project URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/SchweizerischeBundesbahnen/scion-microfrontend-platform.git"
+    "url": "https://github.com/SchweizerischeBundesbahnen/scion-microfrontend-platform.git"
   }
 }

--- a/projects/scion/microfrontend-platform/package.json
+++ b/projects/scion/microfrontend-platform/package.json
@@ -7,9 +7,9 @@
   "publishConfig": {
     "access": "public"
   },
-  "homepage": "https://github.com/SchweizerischeBundesbahnen/microfrontend-platform",
+  "homepage": "https://github.com/SchweizerischeBundesbahnen/scion-microfrontend-platform",
   "bugs": {
-    "url": "https://github.com/SchweizerischeBundesbahnen/microfrontend-platform/issues"
+    "url": "https://github.com/SchweizerischeBundesbahnen/scion-microfrontend-platform/issues"
   },
   "author": {
     "name": "SCION contributors"
@@ -44,6 +44,6 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/SchweizerischeBundesbahnen/microfrontend-platform.git"
+    "url": "https://github.com/SchweizerischeBundesbahnen/scion-microfrontend-platform.git"
   }
 }


### PR DESCRIPTION
The misspelled project URL in package.json causes the NPM registry to point to the SCION Workbench GitHub repo instead of the SCION Microfrontend GitHub repo.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/SchweizerischeBundesbahnen/scion-microfrontend-platform/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes and features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Fix (bug fix)
- [ ] Feature (new feature)
- [ ] Documentation (changes to the documentation)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance (changes that improve performance)
- [ ] Test (adding missing tests, refactoring tests; no production code change)
- [x] Chore (other changes like formatting, updating the license, updating dependencies, removal of deprecations, etc)
- [ ] CI (changes to our CI configuration files and scripts)
- [ ] Revert (revert of a previous commit)
- [ ] Release (publish a new release)
- [ ] Other... Please describe:


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

