### PR TITLE
fix(platform): substitute falsy values in named parameters of URL

### DIFF
--- a/projects/scion/microfrontend-platform/src/lib/client/router-outlet/named-parameter-substitution.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/client/router-outlet/named-parameter-substitution.spec.ts
@@ -139,6 +139,18 @@ describe('OutletRouter', () => {
         });
         await expectAsync(url).toBeResolvedTo(`${options.expectedBasePath}a/PARAM1/b/PARAM2;mp1=PARAM3;mp2=PARAM4;mp3=PARAM1;m4=static?qp1=PARAM5&qp2=PARAM6&qp3=static#frag_PARAM7`);
       });
+
+      it('should substitute falsy params', async () => {
+        const url = navigate(`${basePath}a?orderId=:orderId&flag=:flag&object=:object&undefined=:undefined`, {
+          params: new Map()
+          .set('orderId', 0)
+          .set('flag', false)
+          .set('object', null)
+          .set('undefined', undefined),
+          relativeTo: options.relativeTo,
+        });
+        await expectAsync(url).toBeResolvedTo(`${options.expectedBasePath}a?orderId=0&flag=false&object=null&undefined=undefined`);
+      });
     }
 
     async function navigate(url: string, navigationOptions: NavigationOptions): Promise<string> {

--- a/projects/scion/microfrontend-platform/src/lib/client/router-outlet/outlet-router.ts
+++ b/projects/scion/microfrontend-platform/src/lib/client/router-outlet/outlet-router.ts
@@ -168,6 +168,6 @@ export class OutletRouter {
   private substituteNamedParameters(path: string, params?: Map<string, any>): string {
     // A named parameter can be followed by another path segment (`/`), by a query param (`?` or `&`), by a matrix param (`;`)
     // or by the fragment part (`#`).
-    return path.replace(/:([^/;&?#]+)/g, (match, $1) => params.get($1) || match);
+    return path.replace(/:([^/;&?#]+)/g, (match, $1) => params.has($1) ? params.get($1) : match);
   }
 }


### PR DESCRIPTION
closes #24

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our [guidelines](https://github.com/SchweizerischeBundesbahnen/scion-microfrontend-platform/blob/master/CONTRIBUTING.md)
- [X] Tests for the changes have been added
- [ ] Docs have been added or updated


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance (changes that improve performance)
- [ ] Test (adding missing tests, refactoring tests; no production code change)
- [ ] Chore (other changes like formatting, updating the license, updating dependencies, removal of deprecations, etc)
- [ ] CI (changes to our CI configuration files and scripts)
- [ ] Revert (revert of a previous commit)
- [ ] Release (publish a new release)
- [ ] Other... Please describe:

## Issue

Issue Number: #24 

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I am not sure if I screwed up the file encodings. `npm before-push` complains about files I did not touch and the encoding of the changed files should be correct. autocrlf is enabled in the git config. I guess the build of the PR will show if there would be any issues.

I decided against using nullish coalescing to also substitute `null` and `undefined`. Although I hope nobody uses this, I think it is more likely to be the expected behaviour.