### PR TITLE
fix(platform): transport `undefined` responses to requestor in request-response communication if `MessageClient#onMessage` and `IntentClient#onIntent` return an Observable

### DIFF
--- a/projects/scion/microfrontend-platform/src/lib/client/messaging/intent-client.ts
+++ b/projects/scion/microfrontend-platform/src/lib/client/messaging/intent-client.ts
@@ -139,8 +139,11 @@ export abstract class IntentClient {
    * For each intent received, the specified callback function is called. When used in request-response communication,
    * the callback function can return the response either directly or in the form of a Promise or Observable. Returning a Promise
    * allows the response to be computed asynchronously, and an Observable allows to return one or more responses, e.g., for
-   * streaming data. In either case, when the final response is produced, the handler terminates the communication, completing
-   * the requestor's Observable. If the callback throws an error, or the returned Promise or Observable errors, the error is
+   * streaming data.
+   * If the callback function returns no value (void), returns `undefined`, or returns a Promise that resolves to `undefined`, communication is terminated
+   * immediately without a response. If the callback returns an Observable, all its emissions are transported to the requestor and communication is not
+   * terminated until the Observable completes. Termination of communication always completes the requestor's Observable.
+   * If the callback throws an error, or the returned Promise or Observable errors, the error is
    * transported to the requestor, erroring the requestor's Observable.
    *
    * @param  selector - Allows filtering intents.

--- a/projects/scion/microfrontend-platform/src/lib/client/messaging/message-client.ts
+++ b/projects/scion/microfrontend-platform/src/lib/client/messaging/message-client.ts
@@ -128,8 +128,11 @@ export abstract class MessageClient {
    * For each message received, the specified callback function is called. When used in request-response communication,
    * the callback function can return the response either directly or in the form of a Promise or Observable. Returning a Promise
    * allows the response to be computed asynchronously, and an Observable allows to return one or more responses, e.g., for
-   * streaming data. In either case, when the final response is produced, the handler terminates the communication, completing
-   * the requestor's Observable. If the callback throws an error, or the returned Promise or Observable errors, the error is
+   * streaming data.
+   * If the callback function returns no value (void), returns `undefined`, or returns a Promise that resolves to `undefined`, communication is terminated
+   * immediately without a response. If the callback returns an Observable, all its emissions are transported to the requestor and communication is not
+   * terminated until the Observable completes. Termination of communication always completes the requestor's Observable.
+   * If the callback throws an error, or the returned Promise or Observable errors, the error is
    * transported to the requestor, erroring the requestor's Observable.
    *
    * @param  topic - Specifies the topic which to observe.

--- a/projects/scion/microfrontend-platform/src/lib/client/messaging/message-handler.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/client/messaging/message-handler.spec.ts
@@ -268,7 +268,37 @@ describe('Message Handler', () => {
       await expect(captor.hasCompleted()).toBeTrue();
     });
 
-    it('should ignore `undefined` values, but not `null` values', async () => {
+    it('should immediately complete the requestor\'s Observable when returning a Promise that resolves without value', async () => {
+      await MicrofrontendPlatform.startHost({applications: []});
+
+      Beans.get(MessageClient).onMessage<string>('topic', () => {
+        return Promise.resolve();
+      });
+
+      const captor = new ObserveCaptor(bodyExtractFn);
+      Beans.get(MessageClient).request$('topic', 'a').subscribe(captor);
+
+      await captor.waitUntilCompletedOrErrored();
+      await expect(captor.getValues()).toEqual([]);
+      await expect(captor.hasCompleted()).toBeTrue();
+    });
+
+    it('should immediately complete the requestor\'s Observable when returning a Promise that resolves with `undefined`', async () => {
+      await MicrofrontendPlatform.startHost({applications: []});
+
+      Beans.get(MessageClient).onMessage<string>('topic', () => {
+        return Promise.resolve(undefined);
+      });
+
+      const captor = new ObserveCaptor(bodyExtractFn);
+      Beans.get(MessageClient).request$('topic', 'a').subscribe(captor);
+
+      await captor.waitUntilCompletedOrErrored();
+      await expect(captor.getValues()).toEqual([]);
+      await expect(captor.hasCompleted()).toBeTrue();
+    });
+
+    it('should transport `undefined` and `null` values emitted by an Observable', async () => {
       await MicrofrontendPlatform.startHost({applications: []});
 
       Beans.get(MessageClient).onMessage<string>('topic', message => {
@@ -280,7 +310,7 @@ describe('Message Handler', () => {
       Beans.get(MessageClient).request$('topic', 'a').subscribe(captor);
 
       await captor.waitUntilCompletedOrErrored();
-      await expect(captor.getValues()).toEqual(['A-1', 'A-2', null, 'A-3']);
+      await expect(captor.getValues()).toEqual(['A-1', undefined, 'A-2', null, 'A-3']);
       await expect(captor.hasCompleted()).toBeTrue();
     });
 
@@ -888,7 +918,53 @@ describe('Intent Handler', () => {
       await expect(captor.hasCompleted()).toBeTrue();
     });
 
-    it('should ignore `undefined` values, but not `null` values', async () => {
+    it('should immediately complete the requestor\'s Observable when returning a Promise that resolves without value', async () => {
+      await MicrofrontendPlatform.startHost({
+        host: {
+          manifest: {
+            name: 'Host App',
+            capabilities: [{type: 'capability'}],
+          },
+        },
+        applications: [],
+      });
+
+      Beans.get(IntentClient).onIntent<string>({type: 'capability'}, () => {
+        return Promise.resolve();
+      });
+
+      const captor = new ObserveCaptor(bodyExtractFn);
+      Beans.get(IntentClient).request$({type: 'capability'}, 'a').subscribe(captor);
+
+      await captor.waitUntilCompletedOrErrored();
+      await expect(captor.getValues()).toEqual([]);
+      await expect(captor.hasCompleted()).toBeTrue();
+    });
+
+    it('should immediately complete the requestor\'s Observable when returning a Promise that resolves with `undefined`', async () => {
+      await MicrofrontendPlatform.startHost({
+        host: {
+          manifest: {
+            name: 'Host App',
+            capabilities: [{type: 'capability'}],
+          },
+        },
+        applications: [],
+      });
+
+      Beans.get(IntentClient).onIntent<string>({type: 'capability'}, () => {
+        return Promise.resolve(undefined);
+      });
+
+      const captor = new ObserveCaptor(bodyExtractFn);
+      Beans.get(IntentClient).request$({type: 'capability'}, 'a').subscribe(captor);
+
+      await captor.waitUntilCompletedOrErrored();
+      await expect(captor.getValues()).toEqual([]);
+      await expect(captor.hasCompleted()).toBeTrue();
+    });
+
+    it('should transport `undefined` and `null` values emitted by an Observable', async () => {
       await MicrofrontendPlatform.startHost({
         host: {
           manifest: {
@@ -908,7 +984,7 @@ describe('Intent Handler', () => {
       Beans.get(IntentClient).request$({type: 'capability'}, 'a').subscribe(captor);
 
       await captor.waitUntilCompletedOrErrored();
-      await expect(captor.getValues()).toEqual(['A-1', 'A-2', null, 'A-3']);
+      await expect(captor.getValues()).toEqual(['A-1', undefined, 'A-2', null, 'A-3']);
       await expect(captor.hasCompleted()).toBeTrue();
     });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/SchweizerischeBundesbahnen/scion-microfrontend-platform/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added
- [x] Docs have been added or updated


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance (changes that improve performance)
- [ ] Test (adding missing tests, refactoring tests; no production code change)
- [ ] Chore (other changes like formatting, updating the license, removal of deprecations, etc)
- [ ] Deps (changes related to updating dependencies)
- [ ] CI (changes to our CI configuration files and scripts)
- [ ] Revert (revert of a previous commit)
- [ ] Release (publish a new release)
- [ ] Other... Please describe:

## Issue

Issue Number: #164 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
