### PR TITLE
feat(platform): use unique identifier for capability and intention ID

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "@scion/components": "14.0.2",
         "@scion/components.internal": "14.0.1",
         "@scion/toolkit": "1.2.1",
-        "js-sha256": "0.9.0",
         "rxjs": "7.5.7",
         "tslib": "2.4.0",
         "zone.js": "0.11.8"
@@ -10544,11 +10543,6 @@
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
       "integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==",
       "dev": true
-    },
-    "node_modules/js-sha256": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
-      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -25072,11 +25066,6 @@
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
       "integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==",
       "dev": true
-    },
-    "js-sha256": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
-      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "@scion/components": "14.0.2",
     "@scion/components.internal": "14.0.1",
     "@scion/toolkit": "1.2.1",
-    "js-sha256": "0.9.0",
     "rxjs": "7.5.7",
     "tslib": "2.4.0",
     "zone.js": "0.11.8"

--- a/projects/scion/microfrontend-platform/ng-package.json
+++ b/projects/scion/microfrontend-platform/ng-package.json
@@ -5,7 +5,6 @@
     "entryFile": "src/public-api.ts"
   },
   "allowedNonPeerDependencies": [
-    "@scion",
-    "js-sha256"
+    "@scion"
   ]
 }

--- a/projects/scion/microfrontend-platform/package.json
+++ b/projects/scion/microfrontend-platform/package.json
@@ -15,7 +15,6 @@
     "name": "SCION contributors"
   },
   "dependencies": {
-    "js-sha256": "^0.9.0",
     "tslib": "^2.3.0"
   },
   "peerDependencies": {

--- a/projects/scion/microfrontend-platform/src/lib/host/manifest-registry/manifest-registry.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/host/manifest-registry/manifest-registry.spec.ts
@@ -686,4 +686,26 @@ describe('ManifestRegistry', () => {
     const actual = (await firstValueFrom(Beans.get(ManifestService).lookupCapabilities$({type: 'testee'})))[0];
     expect(actual.metadata.id).toEqual('1');
   });
+
+  it('should use a unique identifier for capability ID', async () => {
+    await MicrofrontendPlatform.startHost({
+      host: {symbolicName: 'host-app'},
+      applications: [],
+    });
+
+    const id1 = await Beans.get(ManifestRegistry).registerCapability({type: 'testee'}, 'host-app');
+    const id2 = await Beans.get(ManifestRegistry).registerCapability({type: 'testee'}, 'host-app');
+    expect(id1).not.toEqual(id2);
+  });
+
+  it('should use a unique identifier for intention ID', async () => {
+    await MicrofrontendPlatform.startHost({
+      host: {symbolicName: 'host-app'},
+      applications: [],
+    });
+
+    const id1 = Beans.get(ManifestRegistry).registerIntention({type: 'testee'}, 'host-app');
+    const id2 = Beans.get(ManifestRegistry).registerIntention({type: 'testee'}, 'host-app');
+    expect(id1).not.toEqual(id2);
+  });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/SchweizerischeBundesbahnen/scion-microfrontend-platform/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added
- [ ] Docs have been added or updated


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance (changes that improve performance)
- [ ] Test (adding missing tests, refactoring tests; no production code change)
- [ ] Chore (other changes like formatting, updating the license, removal of deprecations, etc)
- [ ] Deps (changes related to updating dependencies)
- [ ] CI (changes to our CI configuration files and scripts)
- [ ] Revert (revert of a previous commit)
- [ ] Release (publish a new release)
- [ ] Other... Please describe:

## Issue

Issue Number: #162 #171 

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

BREAKING CHANGE: Using unique identifier for capability and intention ID introduced a breaking change.

Previously, the IDs used for capabilities and intentions were stable but not unique, which caused problems when deregistering capabilities and intentions. If your application requires stable capability identifiers, you can register a capability interceptor, as follows:

```ts
import {Capability, CapabilityInterceptor} from '@scion/microfrontend-platform';
import {Crypto} from '@scion/toolkit/crypto';
import {Beans} from '@scion/toolkit/bean-manager';

Beans.register(CapabilityInterceptor, {
  useValue: new class implements CapabilityInterceptor {
    public async intercept(capability: Capability): Promise<Capability> {
      const stableId = await Crypto.digest(JSON.stringify({
        type: capability.type,
        qualifier: capability.qualifier,
        application: capability.metadata!.appSymbolicName,
      }));
      return {
        ...capability,
        metadata: {...capability.metadata!, id: stableId},
      };
    }
  },
  multi: true
})
```

Note that the communication protocol between host and client has NOT changed. You can independently upgrade host and clients to the new version.