### PR TITLE
fix(platform/messaging): stop platform in `beforeunload` to avoid posting messages to disposed window

### DIFF
--- a/apps/microfrontend-platform-testing-app/src/app/app-routing.module.ts
+++ b/apps/microfrontend-platform-testing-app/src/app/app-routing.module.ts
@@ -52,6 +52,7 @@ const routes: Routes = [
       {path: 'scrollable-microfrontend', component: ScrollableMicrofrontendComponent, data: {pageTitle: 'Displays a microfrontend with some tall content displayed in a viewport'}},
       {path: 'preferred-size', component: PreferredSizeComponent, data: {pageTitle: 'Allows playing around with the microfrontend\'s preferred size'}},
       {path: 'platform-properties', component: PlatformPropertiesComponent, data: {pageTitle: 'Shows properties that are registered in the platform'}},
+      {path: 'test-pages', loadChildren: (): any => import('./test-pages/test-pages-routing.module').then(m => m.TestPagesRoutingModule)},
     ],
   },
 ];

--- a/apps/microfrontend-platform-testing-app/src/app/test-pages/clear-outlet-then-send-message-test-page/clear-outlet-then-send-message-test-page.component.html
+++ b/apps/microfrontend-platform-testing-app/src/app/test-pages/clear-outlet-then-send-message-test-page/clear-outlet-then-send-message-test-page.component.html
@@ -1,0 +1,12 @@
+<form autocomplete="off" [formGroup]="form">
+  <sci-form-field label="Router Outlet">
+    <input [formControlName]="OUTLET" class="e2e-outlet" title="Specifies the name of the outlet which to clear.">
+  </sci-form-field>
+  <sci-form-field label="Message Topic">
+    <input [formControlName]="TOPIC" class="e2e-topic" title="Specifies the topic where to send a message after cleared the outlet.">
+  </sci-form-field>
+
+  <button type="submit" class="e2e-run-test" [disabled]="form.invalid" (click)="onRunTestClick()">
+    Clear outlet, then send message to topic
+  </button>
+</form>

--- a/apps/microfrontend-platform-testing-app/src/app/test-pages/clear-outlet-then-send-message-test-page/clear-outlet-then-send-message-test-page.component.scss
+++ b/apps/microfrontend-platform-testing-app/src/app/test-pages/clear-outlet-then-send-message-test-page/clear-outlet-then-send-message-test-page.component.scss
@@ -1,0 +1,10 @@
+:host {
+  display: grid;
+
+  > form {
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-auto-rows: max-content;
+    row-gap: .25em;
+  }
+}

--- a/apps/microfrontend-platform-testing-app/src/app/test-pages/clear-outlet-then-send-message-test-page/clear-outlet-then-send-message-test-page.component.ts
+++ b/apps/microfrontend-platform-testing-app/src/app/test-pages/clear-outlet-then-send-message-test-page/clear-outlet-then-send-message-test-page.component.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2018-2022 Swiss Federal Railways
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import {Component} from '@angular/core';
+import {FormControl, FormGroup, ReactiveFormsModule, UntypedFormBuilder, Validators} from '@angular/forms';
+import {MessageClient, OutletRouter} from '@scion/microfrontend-platform';
+import {Beans} from '@scion/toolkit/bean-manager';
+import {SciFormFieldModule} from '@scion/components.internal/form-field';
+
+export const OUTLET = 'outlet';
+export const TOPIC = 'topic';
+
+@Component({
+  selector: 'app-clear-outlet-then-send-message-test-page',
+  templateUrl: './clear-outlet-then-send-message-test-page.component.html',
+  styleUrls: ['./clear-outlet-then-send-message-test-page.component.scss'],
+  standalone: true,
+  imports: [ReactiveFormsModule, SciFormFieldModule],
+})
+export class ClearOutletThenSendMessageTestPageComponent {
+
+  public OUTLET = OUTLET;
+  public TOPIC = TOPIC;
+
+  public form: FormGroup;
+
+  constructor(formBuilder: UntypedFormBuilder) {
+    this.form = formBuilder.group({
+      [OUTLET]: new FormControl<string>('', Validators.required),
+      [TOPIC]: new FormControl<string>('', Validators.required),
+    });
+  }
+
+  public async onRunTestClick(): Promise<void> {
+    // Clear the router outlet.
+    await Beans.get(OutletRouter).navigate(null, {outlet: this.form.get(OUTLET).value});
+    // Send message to the topic.
+    await Beans.get(MessageClient).publish(this.form.get(TOPIC).value);
+    // Reset the form.
+    this.form.reset();
+  }
+}

--- a/apps/microfrontend-platform-testing-app/src/app/test-pages/test-pages-routing.module.ts
+++ b/apps/microfrontend-platform-testing-app/src/app/test-pages/test-pages-routing.module.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2018-2022 Swiss Federal Railways
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+import {NgModule} from '@angular/core';
+import {RouterModule, Routes} from '@angular/router';
+
+const routes: Routes = [
+  {
+    path: 'clear-outlet-then-send-message-test-page',
+    data: {pageTitle: 'Test page that clears an outlet and sends a message'},
+    loadComponent: (): any => import('./clear-outlet-then-send-message-test-page/clear-outlet-then-send-message-test-page.component').then(m => m.ClearOutletThenSendMessageTestPageComponent),
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class TestPagesRoutingModule {
+}

--- a/docs/adoc/microfrontend-platform-developer-guide/chapters/miscellaneous/platform-lifecycle/platform-lifecycle.adoc
+++ b/docs/adoc/microfrontend-platform-developer-guide/chapters/miscellaneous/platform-lifecycle/platform-lifecycle.adoc
@@ -90,7 +90,7 @@ When the platform is stopped, it first enters the `Stopping` platform state. In 
 
 The platform allows the application to send messages while the platform is stopping. After all beans are destroyed, the client is disconnected from the host and the platform enters the `Stopped` state.
 
-By default, the platform initiates platform shutdown when the browser unloads the document. For this purpose, the platform binds to the browser's `unload` event. It does not bind to the `beforeunload` event since the browser fires that event only when navigating to another page, but not when removing the iframe.
+By default, the platform initiates shutdown when the browser unloads the document, i.e., when `beforeunload` is triggered. The main reason for `beforeunload` instead of `unload` is to avoid posting messages to disposed windows. However, if `beforeunload` is not triggered, e.g., when an iframe is removed, we fall back to `unload`.
 
 You can change this behavior by registering a custom `MicrofrontendPlatformStopper` bean, as follows:
 

--- a/docs/adoc/microfrontend-platform-developer-guide/chapters/miscellaneous/platform-lifecycle/platform-lifecycle.snippets.ts
+++ b/docs/adoc/microfrontend-platform-developer-guide/chapters/miscellaneous/platform-lifecycle/platform-lifecycle.snippets.ts
@@ -46,16 +46,16 @@ import {MicrofrontendPlatform, MicrofrontendPlatformStopper, PlatformState} from
 
 {
   // tag::platform-lifecycle:microfrontend-platform-stopper[]
-  class BeforeUnloadMicrofrontendPlatformStopper implements MicrofrontendPlatformStopper {
+  class OnUnloadMicrofrontendPlatformStopper implements MicrofrontendPlatformStopper {
 
     constructor() {
       // Destroys the platform when the document is about to be unloaded.
-      window.addEventListener('beforeunload', () => MicrofrontendPlatform.destroy(), {once: true});
+      window.addEventListener('unload', () => MicrofrontendPlatform.destroy(), {once: true});
     }
   }
 
   // Registers custom platform stopper.
-  Beans.register(MicrofrontendPlatformStopper, {useClass: BeforeUnloadMicrofrontendPlatformStopper});
+  Beans.register(MicrofrontendPlatformStopper, {useClass: OnUnloadMicrofrontendPlatformStopper});
   // end::platform-lifecycle:microfrontend-platform-stopper[]
 }
 

--- a/projects/scion/microfrontend-platform.e2e/src/messaging/messaging.e2e-spec.ts
+++ b/projects/scion/microfrontend-platform.e2e/src/messaging/messaging.e2e-spec.ts
@@ -91,6 +91,10 @@ test.describe('Messaging', () => {
       await TopicBasedMessagingSpecs.passHeadersSpec(testingAppPO);
     });
 
+    test('should stop platform in `beforeunload` to avoid posting messages to disposed windows', async ({testingAppPO, consoleLogs}) => {
+      await TopicBasedMessagingSpecs.doNotPostMessageToDisposedWindow(testingAppPO, consoleLogs);
+    });
+
     test.describe('message-interception', () => {
 
       test('allows intercepting messages', async ({testingAppPO}) => {

--- a/projects/scion/microfrontend-platform.e2e/src/messaging/receive-message-page.po.ts
+++ b/projects/scion/microfrontend-platform.e2e/src/messaging/receive-message-page.po.ts
@@ -18,7 +18,8 @@ import {OutletPageObject} from '../browser-outlet/browser-outlet.po';
 
 export class ReceiveMessagePagePO implements OutletPageObject {
 
-  public readonly path = 'receive-message';
+  public static readonly PATH = 'receive-message';
+  public readonly path = ReceiveMessagePagePO.PATH;
 
   private readonly _locator: Locator;
   private readonly _messageListPO: SciListPO;

--- a/projects/scion/microfrontend-platform.e2e/src/test-pages/clear-outlet-then-send-message-test-page.po.ts
+++ b/projects/scion/microfrontend-platform.e2e/src/test-pages/clear-outlet-then-send-message-test-page.po.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2018-2022 Swiss Federal Railways
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+import {FrameLocator, Locator} from '@playwright/test';
+import {OutletPageObject} from '../browser-outlet/browser-outlet.po';
+
+export class ClearOutletThenSendMessageTestPagePO implements OutletPageObject {
+
+  public readonly path = 'test-pages/clear-outlet-then-send-message-test-page';
+
+  private readonly _locator: Locator;
+
+  constructor(frameLocator: FrameLocator) {
+    this._locator = frameLocator.locator('app-clear-outlet-then-send-message-test-page');
+  }
+
+  public async enterOutletName(outlet: string): Promise<void> {
+    await this._locator.locator('input.e2e-outlet').fill(outlet);
+  }
+
+  public async enterTopic(topic: string): Promise<void> {
+    await this._locator.locator('input.e2e-topic').fill(topic);
+  }
+
+  public async clickRunTest(): Promise<void> {
+    await this._locator.locator('button.e2e-run-test').click();
+  }
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/SchweizerischeBundesbahnen/scion-microfrontend-platform/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added
- [x] Docs have been added or updated


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance (changes that improve performance)
- [ ] Test (adding missing tests, refactoring tests; no production code change)
- [ ] Chore (other changes like formatting, updating the license, removal of deprecations, etc)
- [ ] Deps (changes related to updating dependencies)
- [ ] CI (changes to our CI configuration files and scripts)
- [ ] Revert (revert of a previous commit)
- [ ] Release (publish a new release)
- [ ] Other... Please describe:

## Issue

Issue Number: #168 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
When posting a message to a disposed window, the browser logs "Failed to execute 'postMessage' on 'DOMWindow'" error.
To avoid posting messages to disposed windows, we now disconnect clients already in `beforeunload` instead of `unload`.
However, if `beforeunload` is not triggered, e.g., when an iframe is removed, we fall back to `unload`.