### PR TITLE
feat(platform): drop support for wildcard capability qualifiers and optional wildcard intention qualifiers

### DIFF
--- a/apps/microfrontend-platform-devtools/src/app/dev-tools-manifest.service.ts
+++ b/apps/microfrontend-platform-devtools/src/app/dev-tools-manifest.service.ts
@@ -103,23 +103,14 @@ export class DevToolsManifestService {
   private findFulfillingIntentions$(capability: Capability): Observable<Intention[]> {
     return this._manifestService.lookupIntentions$({type: capability.type})
       .pipe(
-        filterArray(intention => (
-          new QualifierMatcher(intention.qualifier, {evalAsterisk: true, evalOptional: true}).matches(capability.qualifier) ||
-          new QualifierMatcher(capability.qualifier, {evalAsterisk: true, evalOptional: true}).matches(intention.qualifier)
-        )),
+        filterArray(intention => new QualifierMatcher(intention.qualifier).matches(capability.qualifier)),
         filterArray(intention => this.isCapabilityVisibleToApplication(capability, intention.metadata.appSymbolicName)),
       );
   }
 
   private findFulfillingCapabilities$(intention: Intention): Observable<Intention[]> {
-    return this._manifestService.lookupCapabilities$({type: intention.type})
-      .pipe(
-        filterArray(capability => (
-          new QualifierMatcher(intention.qualifier, {evalAsterisk: true, evalOptional: true}).matches(capability.qualifier) ||
-          new QualifierMatcher(capability.qualifier, {evalAsterisk: true, evalOptional: true}).matches(intention.qualifier)
-        )),
-        filterArray(capability => this.isCapabilityVisibleToApplication(capability, intention.metadata.appSymbolicName)),
-      );
+    return this._manifestService.lookupCapabilities$({type: intention.type, qualifier: intention.qualifier})
+      .pipe(filterArray(capability => this.isCapabilityVisibleToApplication(capability, intention.metadata.appSymbolicName)));
   }
 
   private isCapabilityVisibleToApplication(capability: Capability, appSymbolicName: string): boolean {

--- a/docs/adoc/microfrontend-platform-developer-guide/chapters/core-concepts/cross-application-communication/intent-based-messaging.adoc
+++ b/docs/adoc/microfrontend-platform-developer-guide/chapters/core-concepts/cross-application-communication/intent-based-messaging.adoc
@@ -52,7 +52,7 @@ The _type_ of the intention must exactly match the type of the capability we wan
 
 NOTE: A micro application is implicitly qualified to interact with all its capabilities without declaring an intention.
 
-TIP: Using the asterisk wildcard (`*`) or optional wildcard character (`?`) in the qualifier allows matching multiple capabilities with a single intention declaration.
+TIP: Using the asterisk wildcard (`*`) in the qualifier allows matching multiple capabilities with a single intention declaration.
 
 To learn more about an intention, see chapter <<chapter:intention-api:intention>> in <<chapter:intention-api>>.
 

--- a/docs/adoc/microfrontend-platform-developer-guide/chapters/core-concepts/intention-api/intention-api.adoc
+++ b/docs/adoc/microfrontend-platform-developer-guide/chapters/core-concepts/intention-api/intention-api.adoc
@@ -118,12 +118,7 @@ a| `Dictionary`
 a|
 The qualifier is a dictionary of key-value pairs to differentiate capabilities of the same _type_. The qualifier is like an abstract description of the capability. It should include enough information to uniquely identify the capability.
 
-Intents must exactly match the qualifier of the capability, if any. The capability qualifier allows using wildcards (such as `*` or `?`) to match multiple intents simultaneously.
-
-* *Asterisk wildcard character (`{asterisk}`):* +
-Intents must contain such a property, but any value is allowed (except `null` or `undefined`). Use it like this: `{property: '{asterisk}'}`
-* *Optional wildcard character (`?`):* +
-Intents can contain such a property. Use it like this: `{property: '?'}`.
+Intents must exactly match the qualifier of the capability, if any.
 
 | params
 a| `ParamDefinition[]`
@@ -195,12 +190,10 @@ Qualifies the capability which to interact with.
 
 The qualifier is a dictionary of arbitrary key-value pairs to differentiate capabilities of the same _type_.
 
-The intention must exactly match the qualifier of the capability, if any. The intention qualifier allows using wildcards (such as `*` or `?`) to match multiple capabilities simultaneously.
+The intention must exactly match the qualifier of the capability, if any. The intention qualifier allows using wildcards to match multiple capabilities simultaneously.
 
 * *Asterisk wildcard character (`{asterisk}`):* +
 Matches capabilities with such a qualifier property no matter of its value (except `null` or `undefined`). Use it like this: `{property: '{asterisk}'}`.
-* *Optional wildcard character (`?`):* +
-Matches capabilities regardless of having or not having such a property. Use it like this: `{property: '?'}`.
 * *Partial wildcard (`{asterisk}{asterisk}`):* +
 Matches capabilities even if having additional properties. Use it like this: `{'{asterisk}': '{asterisk}'}`.
 

--- a/projects/scion/microfrontend-platform.e2e/src/manifest/manifest-registry.e2e-spec.ts
+++ b/projects/scion/microfrontend-platform.e2e/src/manifest/manifest-registry.e2e-spec.ts
@@ -184,40 +184,13 @@ test.describe('Manifest Registry', () => {
       const capability3Id = await registratorPO.registerCapability({type: 'type3', qualifier: {key: 'a'}, private: true});
       const capability4Id = await registratorPO.registerCapability({type: 'type4', qualifier: {key: 'b'}, private: true});
       const capability5Id = await registratorPO.registerCapability({type: 'type5', qualifier: {key: 'c'}, private: true});
-      const capability6Id = await registratorPO.registerCapability({type: 'type6', qualifier: {key: '*'}, private: true});
-      const capability7Id = await registratorPO.registerCapability({type: 'type7', qualifier: {key: '?'}, private: true});
-      const capability8Id = await registratorPO.registerCapability({type: 'type8', qualifier: {otherKey: '?'}, private: true});
+      const capability6Id = await registratorPO.registerCapability({type: 'type6', qualifier: {otherKey: 'a'}, private: true});
       await lookupPO.lookup();
-      await expect(await lookupPO.getLookedUpCapabilityIds()).toEqualIgnoreOrder([capability1Id, capability2Id, capability3Id, capability4Id, capability5Id, capability6Id, capability7Id, capability8Id]);
+      await expect(await lookupPO.getLookedUpCapabilityIds()).toEqualIgnoreOrder([capability1Id, capability2Id, capability3Id, capability4Id, capability5Id, capability6Id]);
 
       // Unregister by qualifier {key: '*'}
       await registratorPO.unregisterCapability({qualifier: {key: '*'}});
-      await expect(await lookupPO.getLookedUpCapabilityIds()).toEqualIgnoreOrder([capability1Id, capability2Id, capability8Id]);
-    });
-
-    test('should interpret the question mark (?) as value (and not as wildcard) when removing capabilities', async ({testingAppPO}) => {
-      const pagePOs = await testingAppPO.navigateTo({
-        registrator: RegisterCapabilityPagePO,
-        lookup: LookupCapabilityPagePO,
-      }, {queryParams: new Map().set('activatorApiDisabled', true)});
-      const registratorPO = pagePOs.get<RegisterCapabilityPagePO>('registrator');
-      const lookupPO = pagePOs.get<LookupCapabilityPagePO>('lookup');
-
-      // Register capabilities
-      const capability1Id = await registratorPO.registerCapability({type: 'type1', qualifier: undefined, private: true});
-      const capability2Id = await registratorPO.registerCapability({type: 'type2', qualifier: {}, private: true});
-      const capability3Id = await registratorPO.registerCapability({type: 'type3', qualifier: {key: 'a'}, private: true});
-      const capability4Id = await registratorPO.registerCapability({type: 'type4', qualifier: {key: 'b'}, private: true});
-      const capability5Id = await registratorPO.registerCapability({type: 'type5', qualifier: {key: 'c'}, private: true});
-      const capability6Id = await registratorPO.registerCapability({type: 'type6', qualifier: {key: '*'}, private: true});
-      const capability7Id = await registratorPO.registerCapability({type: 'type7', qualifier: {key: '?'}, private: true});
-      const capability8Id = await registratorPO.registerCapability({type: 'type8', qualifier: {otherKey: '?'}, private: true});
-      await lookupPO.lookup();
-      await expect(await lookupPO.getLookedUpCapabilityIds()).toEqualIgnoreOrder([capability1Id, capability2Id, capability3Id, capability4Id, capability5Id, capability6Id, capability7Id, capability8Id]);
-
-      // Unregister by qualifier {key: '?'}
-      await registratorPO.unregisterCapability({qualifier: {key: '?'}});
-      await expect(await lookupPO.getLookedUpCapabilityIds()).toEqualIgnoreOrder([capability1Id, capability2Id, capability3Id, capability4Id, capability5Id, capability6Id, capability8Id]);
+      await expect(await lookupPO.getLookedUpCapabilityIds()).toEqualIgnoreOrder([capability1Id, capability2Id, capability6Id]);
     });
 
     test('should allow to unregister all capabilities by `AnyQualifier`', async ({testingAppPO}) => {
@@ -234,11 +207,9 @@ test.describe('Manifest Registry', () => {
       const capability3Id = await registratorPO.registerCapability({type: 'type3', qualifier: {key: 'a'}, private: true});
       const capability4Id = await registratorPO.registerCapability({type: 'type4', qualifier: {key: 'b'}, private: true});
       const capability5Id = await registratorPO.registerCapability({type: 'type5', qualifier: {key: 'c'}, private: true});
-      const capability6Id = await registratorPO.registerCapability({type: 'type6', qualifier: {key: '*'}, private: true});
-      const capability7Id = await registratorPO.registerCapability({type: 'type7', qualifier: {key: '?'}, private: true});
-      const capability8Id = await registratorPO.registerCapability({type: 'type8', qualifier: {otherKey: '?'}, private: true});
+      const capability6Id = await registratorPO.registerCapability({type: 'type6', qualifier: {otherKey: 'a'}, private: true});
       await lookupPO.lookup();
-      await expect(await lookupPO.getLookedUpCapabilityIds()).toEqualIgnoreOrder([capability1Id, capability2Id, capability3Id, capability4Id, capability5Id, capability6Id, capability7Id, capability8Id]);
+      await expect(await lookupPO.getLookedUpCapabilityIds()).toEqualIgnoreOrder([capability1Id, capability2Id, capability3Id, capability4Id, capability5Id, capability6Id]);
 
       // Unregister by qualifier {'*': '*'}
       await registratorPO.unregisterCapability({qualifier: {'*': '*'}});
@@ -257,20 +228,13 @@ test.describe('Manifest Registry', () => {
       const capability1Id = await registratorPO.registerCapability({type: 'type1', qualifier: undefined, private: true});
       const capability2Id = await registratorPO.registerCapability({type: 'type2', qualifier: {}, private: true});
       const capability3Id = await registratorPO.registerCapability({type: 'type3', qualifier: {key: 'a', otherKey: 'z'}, private: true});
-      const capability4Id = await registratorPO.registerCapability({type: 'type4', qualifier: {key: 'b', otherKey: '*'}, private: true});
-      const capability5Id = await registratorPO.registerCapability({type: 'type5', qualifier: {key: 'c', otherKey: '?'}, private: true});
-      const capability6Id = await registratorPO.registerCapability({type: 'type6', qualifier: {key: '*', otherKey: '*'}, private: true});
-      const capability7Id = await registratorPO.registerCapability({type: 'type7', qualifier: {key: '?', otherKey: '?'}, private: true});
+      const capability4Id = await registratorPO.registerCapability({type: 'type4', qualifier: {key: 'b', otherKey: 'y'}, private: true});
       await lookupPO.lookup();
-      await expect(await lookupPO.getLookedUpCapabilityIds()).toEqualIgnoreOrder([capability1Id, capability2Id, capability3Id, capability4Id, capability5Id, capability6Id, capability7Id]);
+      await expect(await lookupPO.getLookedUpCapabilityIds()).toEqualIgnoreOrder([capability1Id, capability2Id, capability3Id, capability4Id]);
 
       // Unregister by qualifier {key: '*'}
       await registratorPO.unregisterCapability({qualifier: {key: '*'}});
-      await expect(await lookupPO.getLookedUpCapabilityIds()).toEqualIgnoreOrder([capability1Id, capability2Id, capability3Id, capability4Id, capability5Id, capability6Id, capability7Id]);
-
-      // Unregister by qualifier {key: '?'}
-      await registratorPO.unregisterCapability({qualifier: {key: '?'}});
-      await expect(await lookupPO.getLookedUpCapabilityIds()).toEqualIgnoreOrder([capability1Id, capability2Id, capability3Id, capability4Id, capability5Id, capability6Id, capability7Id]);
+      await expect(await lookupPO.getLookedUpCapabilityIds()).toEqualIgnoreOrder([capability1Id, capability2Id, capability3Id, capability4Id]);
 
       // Unregister by qualifier {'*': '*'}
       await registratorPO.unregisterCapability({qualifier: {'*': '*'}});
@@ -291,26 +255,12 @@ test.describe('Manifest Registry', () => {
       const capability3Id = await registratorPO.registerCapability({type: 'type3', qualifier: {key: 'a'}, private: true});
       const capability4Id = await registratorPO.registerCapability({type: 'type4', qualifier: {key: 'b'}, private: true});
       const capability5Id = await registratorPO.registerCapability({type: 'type5', qualifier: {key: 'c'}, private: true});
-      const capability6Id = await registratorPO.registerCapability({type: 'type6', qualifier: {key: '*'}, private: true});
-      const capability7Id = await registratorPO.registerCapability({type: 'type7', qualifier: {key: '?'}, private: true});
       await lookupPO.lookup();
-      await expect(await lookupPO.getLookedUpCapabilityIds()).toEqualIgnoreOrder([capability1Id, capability2Id, capability3Id, capability4Id, capability5Id, capability6Id, capability7Id]);
+      await expect(await lookupPO.getLookedUpCapabilityIds()).toEqualIgnoreOrder([capability1Id, capability2Id, capability3Id, capability4Id, capability5Id]);
 
       // Unregister by qualifier {key: '*', otherKey: '*'}
       await registratorPO.unregisterCapability({qualifier: {key: '*', otherKey: '*'}});
-      await expect(await lookupPO.getLookedUpCapabilityIds()).toEqualIgnoreOrder([capability1Id, capability2Id, capability3Id, capability4Id, capability5Id, capability6Id, capability7Id]);
-
-      // Unregister by qualifier {key: '?', otherKey: '*'}
-      await registratorPO.unregisterCapability({qualifier: {key: '?', otherKey: '*'}});
-      await expect(await lookupPO.getLookedUpCapabilityIds()).toEqualIgnoreOrder([capability1Id, capability2Id, capability3Id, capability4Id, capability5Id, capability6Id, capability7Id]);
-
-      // Unregister by qualifier {key: '*', otherKey: '?'}
-      await registratorPO.unregisterCapability({qualifier: {key: '*', otherKey: '?'}});
-      await expect(await lookupPO.getLookedUpCapabilityIds()).toEqualIgnoreOrder([capability1Id, capability2Id, capability3Id, capability4Id, capability5Id, capability6Id, capability7Id]);
-
-      // Unregister by qualifier {key: '?', otherKey: '?'}
-      await registratorPO.unregisterCapability({qualifier: {key: '?', otherKey: '?'}});
-      await expect(await lookupPO.getLookedUpCapabilityIds()).toEqualIgnoreOrder([capability1Id, capability2Id, capability3Id, capability4Id, capability5Id, capability6Id, capability7Id]);
+      await expect(await lookupPO.getLookedUpCapabilityIds()).toEqualIgnoreOrder([capability1Id, capability2Id, capability3Id, capability4Id, capability5Id]);
     });
 
     test('should not allow to unregister capabilities from other applications', async ({testingAppPO}) => {
@@ -780,43 +730,15 @@ test.describe('Manifest Registry', () => {
       const intention4Id = await registratorPO.registerIntention({type: 'type4', qualifier: {key: 'b'}});
       const intention5Id = await registratorPO.registerIntention({type: 'type5', qualifier: {key: 'c'}});
       const intention6Id = await registratorPO.registerIntention({type: 'type6', qualifier: {key: '*'}});
-      const intention7Id = await registratorPO.registerIntention({type: 'type7', qualifier: {key: '?'}});
-      const intention8Id = await registratorPO.registerIntention({type: 'type8', qualifier: {otherKey: '?'}});
-      const intention9Id = await registratorPO.registerIntention({type: 'type9', qualifier: {'*': '*'}});
-      const intention10Id = await registratorPO.registerIntention({type: 'type10', qualifier: {'*': '*', 'key': '*'}});
+      const intention7Id = await registratorPO.registerIntention({type: 'type7', qualifier: {otherKey: 'a'}});
+      const intention8Id = await registratorPO.registerIntention({type: 'type8', qualifier: {'*': '*'}});
+      const intention9Id = await registratorPO.registerIntention({type: 'type9', qualifier: {'*': '*', 'key': '*'}});
       await lookupPO.lookup();
-      await expect(await lookupPO.getLookedUpIntentionIds()).toEqualIgnoreOrder([intention1Id, intention2Id, intention3Id, intention4Id, intention5Id, intention6Id, intention7Id, intention8Id, intention9Id, intention10Id]);
+      await expect(await lookupPO.getLookedUpIntentionIds()).toEqualIgnoreOrder([intention1Id, intention2Id, intention3Id, intention4Id, intention5Id, intention6Id, intention7Id, intention8Id, intention9Id]);
 
       // Unregister by qualifier {key: '*'}
       await registratorPO.unregisterIntentions({qualifier: {key: '*'}});
-      await expect(await lookupPO.getLookedUpIntentionIds()).toEqual([intention1Id, intention2Id, intention8Id, intention9Id, intention10Id]);
-    });
-
-    test('should interpret the question mark (?) as value (and not as wildcard) when removing intentions', async ({testingAppPO}) => {
-      const pagePOs = await testingAppPO.navigateTo({
-        registrator: RegisterIntentionPagePO,
-        lookup: LookupIntentionPagePO,
-      }, {queryParams: new Map().set('activatorApiDisabled', true)});
-      const registratorPO = pagePOs.get<RegisterIntentionPagePO>('registrator');
-      const lookupPO = pagePOs.get<LookupIntentionPagePO>('lookup');
-
-      // Register intentions
-      const intention1Id = await registratorPO.registerIntention({type: 'type1', qualifier: undefined});
-      const intention2Id = await registratorPO.registerIntention({type: 'type2', qualifier: {}});
-      const intention3Id = await registratorPO.registerIntention({type: 'type3', qualifier: {key: 'a'}});
-      const intention4Id = await registratorPO.registerIntention({type: 'type4', qualifier: {key: 'b'}});
-      const intention5Id = await registratorPO.registerIntention({type: 'type5', qualifier: {key: 'c'}});
-      const intention6Id = await registratorPO.registerIntention({type: 'type6', qualifier: {key: '*'}});
-      const intention7Id = await registratorPO.registerIntention({type: 'type7', qualifier: {key: '?'}});
-      const intention8Id = await registratorPO.registerIntention({type: 'type8', qualifier: {otherKey: '?'}});
-      const intention9Id = await registratorPO.registerIntention({type: 'type9', qualifier: {'*': '*'}});
-      const intention10Id = await registratorPO.registerIntention({type: 'type10', qualifier: {'*': '*', 'key': '*'}});
-      await lookupPO.lookup();
-      await expect(await lookupPO.getLookedUpIntentionIds()).toEqualIgnoreOrder([intention1Id, intention2Id, intention3Id, intention4Id, intention5Id, intention6Id, intention7Id, intention8Id, intention9Id, intention10Id]);
-
-      // Unregister by qualifier {key: '?'}
-      await registratorPO.unregisterIntentions({qualifier: {key: '?'}});
-      await expect(await lookupPO.getLookedUpIntentionIds()).toEqual([intention1Id, intention2Id, intention3Id, intention4Id, intention5Id, intention6Id, intention8Id, intention9Id, intention10Id]);
+      await expect(await lookupPO.getLookedUpIntentionIds()).toEqual([intention1Id, intention2Id, intention7Id, intention8Id, intention9Id]);
     });
 
     test('should allow to unregister intentions by `AnyQualifier`', async ({testingAppPO}) => {
@@ -834,12 +756,11 @@ test.describe('Manifest Registry', () => {
       const intention4Id = await registratorPO.registerIntention({type: 'type4', qualifier: {key: 'b'}});
       const intention5Id = await registratorPO.registerIntention({type: 'type5', qualifier: {key: 'c'}});
       const intention6Id = await registratorPO.registerIntention({type: 'type6', qualifier: {key: '*'}});
-      const intention7Id = await registratorPO.registerIntention({type: 'type7', qualifier: {key: '?'}});
-      const intention8Id = await registratorPO.registerIntention({type: 'type8', qualifier: {otherKey: '?'}});
-      const intention9Id = await registratorPO.registerIntention({type: 'type9', qualifier: {'*': '*'}});
-      const intention10Id = await registratorPO.registerIntention({type: 'type10', qualifier: {'*': '*', 'key': '*'}});
+      const intention7Id = await registratorPO.registerIntention({type: 'type7', qualifier: {otherKey: 'a'}});
+      const intention8Id = await registratorPO.registerIntention({type: 'type8', qualifier: {'*': '*'}});
+      const intention9Id = await registratorPO.registerIntention({type: 'type9', qualifier: {'*': '*', 'key': '*'}});
       await lookupPO.lookup();
-      await expect(await lookupPO.getLookedUpIntentionIds()).toEqualIgnoreOrder([intention1Id, intention2Id, intention3Id, intention4Id, intention5Id, intention6Id, intention7Id, intention8Id, intention9Id, intention10Id]);
+      await expect(await lookupPO.getLookedUpIntentionIds()).toEqualIgnoreOrder([intention1Id, intention2Id, intention3Id, intention4Id, intention5Id, intention6Id, intention7Id, intention8Id, intention9Id]);
 
       // Unregister by qualifier {'*': '*'}
       await registratorPO.unregisterIntentions({qualifier: {'*': '*'}});
@@ -859,21 +780,15 @@ test.describe('Manifest Registry', () => {
       const intention2Id = await registratorPO.registerIntention({type: 'type2', qualifier: {}});
       const intention3Id = await registratorPO.registerIntention({type: 'type3', qualifier: {key: 'a', otherKey: 'z'}});
       const intention4Id = await registratorPO.registerIntention({type: 'type4', qualifier: {key: 'b', otherKey: '*'}});
-      const intention5Id = await registratorPO.registerIntention({type: 'type5', qualifier: {key: 'c', otherKey: '?'}});
-      const intention6Id = await registratorPO.registerIntention({type: 'type6', qualifier: {key: '*', otherKey: '*'}});
-      const intention7Id = await registratorPO.registerIntention({type: 'type7', qualifier: {key: '?', otherKey: '?'}});
-      const intention8Id = await registratorPO.registerIntention({type: 'type8', qualifier: {'*': '*'}});
-      const intention9Id = await registratorPO.registerIntention({type: 'type9', qualifier: {'*': '*', 'key': '*'}});
+      const intention5Id = await registratorPO.registerIntention({type: 'type5', qualifier: {key: '*', otherKey: '*'}});
+      const intention6Id = await registratorPO.registerIntention({type: 'type6', qualifier: {'*': '*'}});
+      const intention7Id = await registratorPO.registerIntention({type: 'type7', qualifier: {'*': '*', 'key': '*'}});
       await lookupPO.lookup();
-      await expect(await lookupPO.getLookedUpIntentionIds()).toEqualIgnoreOrder([intention1Id, intention2Id, intention3Id, intention4Id, intention5Id, intention6Id, intention7Id, intention8Id, intention9Id]);
+      await expect(await lookupPO.getLookedUpIntentionIds()).toEqualIgnoreOrder([intention1Id, intention2Id, intention3Id, intention4Id, intention5Id, intention6Id, intention7Id]);
 
       // Unregister by qualifier {key: '*'}
       await registratorPO.unregisterIntentions({qualifier: {key: '*'}});
-      await expect(await lookupPO.getLookedUpIntentionIds()).toEqual([intention1Id, intention2Id, intention3Id, intention4Id, intention5Id, intention6Id, intention7Id, intention8Id, intention9Id]);
-
-      // Unregister by qualifier {key: '?'}
-      await registratorPO.unregisterIntentions({qualifier: {key: '?'}});
-      await expect(await lookupPO.getLookedUpIntentionIds()).toEqual([intention1Id, intention2Id, intention3Id, intention4Id, intention5Id, intention6Id, intention7Id, intention8Id, intention9Id]);
+      await expect(await lookupPO.getLookedUpIntentionIds()).toEqual([intention1Id, intention2Id, intention3Id, intention4Id, intention5Id, intention6Id, intention7Id]);
 
       // Unregister by qualifier {'*': '*'}
       await registratorPO.unregisterIntentions({qualifier: {'*': '*'}});
@@ -895,31 +810,18 @@ test.describe('Manifest Registry', () => {
       const intention4Id = await registratorPO.registerIntention({type: 'type4', qualifier: {key: 'b'}});
       const intention5Id = await registratorPO.registerIntention({type: 'type5', qualifier: {key: 'c'}});
       const intention6Id = await registratorPO.registerIntention({type: 'type6', qualifier: {key: '*'}});
-      const intention7Id = await registratorPO.registerIntention({type: 'type7', qualifier: {key: '?'}});
-      const intention8Id = await registratorPO.registerIntention({type: 'type8', qualifier: {'*': '*'}});
-      const intention9Id = await registratorPO.registerIntention({type: 'type9', qualifier: {'*': '*', 'key': '*'}});
+      const intention7Id = await registratorPO.registerIntention({type: 'type7', qualifier: {'*': '*'}});
+      const intention8Id = await registratorPO.registerIntention({type: 'type8', qualifier: {'*': '*', 'key': '*'}});
       await lookupPO.lookup();
-      await expect(await lookupPO.getLookedUpIntentionIds()).toEqualIgnoreOrder([intention1Id, intention2Id, intention3Id, intention4Id, intention5Id, intention6Id, intention7Id, intention8Id, intention9Id]);
+      await expect(await lookupPO.getLookedUpIntentionIds()).toEqualIgnoreOrder([intention1Id, intention2Id, intention3Id, intention4Id, intention5Id, intention6Id, intention7Id, intention8Id]);
 
       // Unregister by qualifier {key: '*', otherKey: '*'}
       await registratorPO.unregisterIntentions({qualifier: {key: '*', otherKey: '*'}});
-      await expect(await lookupPO.getLookedUpIntentionIds()).toEqual([intention1Id, intention2Id, intention3Id, intention4Id, intention5Id, intention6Id, intention7Id, intention8Id, intention9Id]);
-
-      // Unregister by qualifier {key: '?', otherKey: '*'}
-      await registratorPO.unregisterIntentions({qualifier: {key: '?', otherKey: '*'}});
-      await expect(await lookupPO.getLookedUpIntentionIds()).toEqual([intention1Id, intention2Id, intention3Id, intention4Id, intention5Id, intention6Id, intention7Id, intention8Id, intention9Id]);
-
-      // Unregister by qualifier {key: '*', otherKey: '?'}
-      await registratorPO.unregisterIntentions({qualifier: {key: '*', otherKey: '?'}});
-      await expect(await lookupPO.getLookedUpIntentionIds()).toEqual([intention1Id, intention2Id, intention3Id, intention4Id, intention5Id, intention6Id, intention7Id, intention8Id, intention9Id]);
-
-      // Unregister by qualifier {key: '?', otherKey: '?'}
-      await registratorPO.unregisterIntentions({qualifier: {key: '?', otherKey: '?'}});
-      await expect(await lookupPO.getLookedUpIntentionIds()).toEqual([intention1Id, intention2Id, intention3Id, intention4Id, intention5Id, intention6Id, intention7Id, intention8Id, intention9Id]);
+      await expect(await lookupPO.getLookedUpIntentionIds()).toEqual([intention1Id, intention2Id, intention3Id, intention4Id, intention5Id, intention6Id, intention7Id, intention8Id]);
 
       // Unregister by qualifier {'*': '*', 'key': '*'}
       await registratorPO.unregisterIntentions({qualifier: {'*': '*', 'key': '*'}});
-      await expect(await lookupPO.getLookedUpIntentionIds()).toEqual([intention1Id, intention2Id, intention8Id]);
+      await expect(await lookupPO.getLookedUpIntentionIds()).toEqual([intention1Id, intention2Id, intention7Id]);
 
       // Unregister by qualifier {'*': '*'}
       await registratorPO.unregisterIntentions({qualifier: {'*': '*'}});

--- a/projects/scion/microfrontend-platform.e2e/src/messaging/messaging.e2e-spec.ts
+++ b/projects/scion/microfrontend-platform.e2e/src/messaging/messaging.e2e-spec.ts
@@ -160,10 +160,6 @@ test.describe('Messaging', () => {
       await IntendBasedMessagingSpecs.receiveAndFilterSpec(testingAppPO);
     });
 
-    test('allows receiving intents for a capability which declares wildcards in its qualifier', async ({testingAppPO}) => {
-      await IntendBasedMessagingSpecs.receiveIfMatchingCapabilityWildcardQualifierSpec(testingAppPO);
-    });
-
     test('allows receiving intents for a capability which declares required and optional params', async ({testingAppPO}) => {
       await IntendBasedMessagingSpecs.receiveIfMatchingCapabilityParamsSpec(testingAppPO);
     });

--- a/projects/scion/microfrontend-platform.e2e/src/router-outlet/router-outlet.e2e-spec.ts
+++ b/projects/scion/microfrontend-platform.e2e/src/router-outlet/router-outlet.e2e-spec.ts
@@ -653,7 +653,6 @@ test.describe('RouterOutlet', () => {
     // Verify that navigation was successful
     await expect(routerOutletPO).toHaveRouterOutletUrl(getPageUrl({path: Microfrontend2PagePO.PATH, origin: TestingAppOrigins.APP_1}));
 
-    // TODO [MSPI] Can you explain why?
     // Navigate back in the browser
     await Promise.race([
       page.waitForEvent('framenavigated'),

--- a/projects/scion/microfrontend-platform/src/lib/client/manifest-registry/manifest-service.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/client/manifest-registry/manifest-service.spec.ts
@@ -29,56 +29,48 @@ describe('ManifestService', () => {
       await MicrofrontendPlatform.startHost({host: {symbolicName: 'host-app'}, applications: []});
 
       // Register capabilities
-      const asteriskQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '*'}}, 'host-app');
-      const optionalQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '?'}}, 'host-app');
-      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'exact'}}, 'host-app');
+      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app');
 
       const qualifier1Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'host-app');
-      const qualifier2Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '*', other: 'property'}}, 'host-app');
-      const qualifier3Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '?', other: 'property'}}, 'host-app');
-      const qualifier4Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'exact', other: 'property'}}, 'host-app');
-      const qualifier5Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
-      const qualifier6Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app');
-      const qualifier7Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null}, 'host-app');
-      const qualifier8Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app');
-      const qualifier9Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app');
+      const qualifier2Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app');
+      const qualifier3Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
+      const qualifier4Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app');
+      const qualifier5Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null}, 'host-app');
+      const qualifier6Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app');
+      const qualifier7Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app');
 
       const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
 
       // Lookup using no qualifier filter
       Beans.get(ManifestService).lookupCapabilities$({type: 'view'}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[asteriskQualifierCapability, optionalQualifierCapability, exactQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability, qualifier4Capability, qualifier5Capability, qualifier6Capability, qualifier7Capability, qualifier8Capability, qualifier9Capability]]);
+      await expectEmissions(captor).toEqual([[exactQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability, qualifier4Capability, qualifier5Capability, qualifier6Capability, qualifier7Capability]]);
 
       // Lookup using qualifier filter: undefined
       Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: undefined}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[asteriskQualifierCapability, optionalQualifierCapability, exactQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability, qualifier4Capability, qualifier5Capability, qualifier6Capability, qualifier7Capability, qualifier8Capability, qualifier9Capability]]);
+      await expectEmissions(captor).toEqual([[exactQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability, qualifier4Capability, qualifier5Capability, qualifier6Capability, qualifier7Capability]]);
 
       // Lookup using qualifier filter: {'*': '*'}
       Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {'*': '*'}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[asteriskQualifierCapability, optionalQualifierCapability, exactQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability, qualifier4Capability, qualifier5Capability, qualifier6Capability, qualifier7Capability, qualifier8Capability, qualifier9Capability]]);
+      await expectEmissions(captor).toEqual([[exactQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability, qualifier4Capability, qualifier5Capability, qualifier6Capability, qualifier7Capability]]);
 
       // Lookup using qualifier filter: {}
       Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[qualifier6Capability, qualifier7Capability, qualifier8Capability, qualifier9Capability]]);
+      await expectEmissions(captor).toEqual([[qualifier4Capability, qualifier5Capability, qualifier6Capability, qualifier7Capability]]);
 
       // Lookup using qualifier filter: null
       Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: null}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[qualifier6Capability, qualifier7Capability, qualifier8Capability, qualifier9Capability]]);
+      await expectEmissions(captor).toEqual([[qualifier4Capability, qualifier5Capability, qualifier6Capability, qualifier7Capability]]);
 
-      // Lookup using qualifier filter: {entity: 'person', id: '*'}
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', id: '*'}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[asteriskQualifierCapability, optionalQualifierCapability, exactQualifierCapability]]);
-
-      // Lookup using qualifier filter: {entity: 'person', id: 'exact'}
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', id: 'exact'}}).subscribe(captor.reset());
+      // Lookup using qualifier filter: {entity: 'person', mode: '*'}
+      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', mode: '*'}}).subscribe(captor.reset());
       await expectEmissions(captor).toEqual([[exactQualifierCapability]]);
 
-      // Lookup using qualifier filter: {entity: 'person', id: '?'}
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', id: '?'}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[optionalQualifierCapability]]);
+      // Lookup using qualifier filter: {entity: 'person', mode: 'new'}
+      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', mode: 'new'}}).subscribe(captor.reset());
+      await expectEmissions(captor).toEqual([[exactQualifierCapability]]);
 
-      // Lookup using qualifier filter: {entity: 'person', id: '999'}
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', id: '999'}}).subscribe(captor.reset());
+      // Lookup using qualifier filter: {entity: 'person', mode: 'edit'}
+      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', mode: 'edit'}}).subscribe(captor.reset());
       await expectEmissions(captor).toEqual([[]]);
 
       // Lookup using qualifier filter: {entity: 'person'}
@@ -87,15 +79,15 @@ describe('ManifestService', () => {
 
       // Lookup using qualifier filter: {entity: 'person', other: 'property'}
       Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', other: 'property'}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[qualifier5Capability]]);
+      await expectEmissions(captor).toEqual([[qualifier3Capability]]);
 
-      // Lookup using qualifier filter: {entity: 'person', id: 'exact', other: 'property'}
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', id: '5', other: 'property'}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[]]);
+      // Lookup using qualifier filter: {entity: 'person', mode: 'new', other: 'property'}
+      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}).subscribe(captor.reset());
+      await expectEmissions(captor).toEqual([[qualifier2Capability]]);
 
       // Lookup using qualifier filter: {entity: 'person', '*': '*'}
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {'entity': 'person', '*': '*'}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[asteriskQualifierCapability, optionalQualifierCapability, exactQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability, qualifier4Capability, qualifier5Capability]]);
+      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', '*': '*'}}).subscribe(captor.reset());
+      await expectEmissions(captor).toEqual([[exactQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability]]);
     });
 
     it('should allow looking up public capabilities of another app (intention contains the any-more wildcard (**))', async () => {
@@ -105,18 +97,14 @@ describe('ManifestService', () => {
       });
 
       // Register intention in host-app: {entity: 'person', '*': '*'}
-      Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {'entity': 'person', '*': '*'}}, 'host-app');
+      Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', '*': '*'}}, 'host-app');
 
       // Register capabilities
-      const asteriskQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '*'}, private: false}, 'app-1');
-      const optionalQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '?'}, private: false}, 'app-1');
-      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'exact'}, private: false}, 'app-1');
+      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}, private: false}, 'app-1');
 
       const qualifier1Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}, private: false}, 'app-1');
-      const qualifier2Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '*', other: 'property'}, private: false}, 'app-1');
-      const qualifier3Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '?', other: 'property'}, private: false}, 'app-1');
-      const qualifier4Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'exact', other: 'property'}, private: false}, 'app-1');
-      const qualifier5Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}, private: false}, 'app-1');
+      const qualifier2Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}, private: false}, 'app-1');
+      const qualifier3Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}, private: false}, 'app-1');
       await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}, private: false}, 'app-1');
       await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null, private: false}, 'app-1');
       await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined, private: false}, 'app-1');
@@ -126,15 +114,15 @@ describe('ManifestService', () => {
 
       // Lookup using no qualifier filter
       Beans.get(ManifestService).lookupCapabilities$({type: 'view'}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[asteriskQualifierCapability, optionalQualifierCapability, exactQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability, qualifier4Capability, qualifier5Capability]]);
+      await expectEmissions(captor).toEqual([[exactQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability]]);
 
       // Lookup using qualifier filter: undefined
       Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: undefined}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[asteriskQualifierCapability, optionalQualifierCapability, exactQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability, qualifier4Capability, qualifier5Capability]]);
+      await expectEmissions(captor).toEqual([[exactQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability]]);
 
       // Lookup using qualifier filter: {'*': '*'}
       Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {'*': '*'}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[asteriskQualifierCapability, optionalQualifierCapability, exactQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability, qualifier4Capability, qualifier5Capability]]);
+      await expectEmissions(captor).toEqual([[exactQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability]]);
 
       // Lookup using qualifier filter: {}
       Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {}}).subscribe(captor.reset());
@@ -144,20 +132,16 @@ describe('ManifestService', () => {
       Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: null}).subscribe(captor.reset());
       await expectEmissions(captor).toEqual([[]]);
 
-      // Lookup using qualifier filter: {entity: 'person', id: '*'}
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', id: '*'}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[asteriskQualifierCapability, optionalQualifierCapability, exactQualifierCapability]]);
-
-      // Lookup using qualifier filter: {entity: 'person', id: 'exact'}
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', id: 'exact'}}).subscribe(captor.reset());
+      // Lookup using qualifier filter: {entity: 'person', mode: '*'}
+      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', mode: '*'}}).subscribe(captor.reset());
       await expectEmissions(captor).toEqual([[exactQualifierCapability]]);
 
-      // Lookup using qualifier filter: {entity: 'person', id: '?'}
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', id: '?'}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[optionalQualifierCapability]]);
+      // Lookup using qualifier filter: {entity: 'person', mode: 'new'}
+      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', mode: 'new'}}).subscribe(captor.reset());
+      await expectEmissions(captor).toEqual([[exactQualifierCapability]]);
 
-      // Lookup using qualifier filter: {entity: 'person', id: '999'}
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', id: '999'}}).subscribe(captor.reset());
+      // Lookup using qualifier filter: {entity: 'person', mode: 'edit'}
+      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', mode: 'edit'}}).subscribe(captor.reset());
       await expectEmissions(captor).toEqual([[]]);
 
       // Lookup using qualifier filter: {entity: 'person'}
@@ -166,15 +150,15 @@ describe('ManifestService', () => {
 
       // Lookup using qualifier filter: {entity: 'person', other: 'property'}
       Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', other: 'property'}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[qualifier5Capability]]);
+      await expectEmissions(captor).toEqual([[qualifier3Capability]]);
 
-      // Lookup using qualifier filter: {entity: 'person', id: 'exact', other: 'property'}
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', id: '5', other: 'property'}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[]]);
+      // Lookup using qualifier filter: {entity: 'person', mode: 'new', other: 'property'}
+      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}).subscribe(captor.reset());
+      await expectEmissions(captor).toEqual([[qualifier2Capability]]);
 
       // Lookup using qualifier filter: {entity: 'person', '*': '*'}
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {'entity': 'person', '*': '*'}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[asteriskQualifierCapability, optionalQualifierCapability, exactQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability, qualifier4Capability, qualifier5Capability]]);
+      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', '*': '*'}}).subscribe(captor.reset());
+      await expectEmissions(captor).toEqual([[exactQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability]]);
     });
 
     it('should allow looking up public capabilities of another app (only any-more wildcard (**) intention)', async () => {
@@ -187,56 +171,48 @@ describe('ManifestService', () => {
       Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {'*': '*'}}, 'host-app');
 
       // Register capabilities
-      const asteriskQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '*'}, private: false}, 'app-1');
-      const optionalQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '?'}, private: false}, 'app-1');
-      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'exact'}, private: false}, 'app-1');
+      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}, private: false}, 'app-1');
 
       const qualifier1Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}, private: false}, 'app-1');
-      const qualifier2Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '*', other: 'property'}, private: false}, 'app-1');
-      const qualifier3Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '?', other: 'property'}, private: false}, 'app-1');
-      const qualifier4Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'exact', other: 'property'}, private: false}, 'app-1');
-      const qualifier5Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}, private: false}, 'app-1');
-      const qualifier6Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}, private: false}, 'app-1');
-      const qualifier7Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null, private: false}, 'app-1');
-      const qualifier8Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined, private: false}, 'app-1');
-      const qualifier9Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', private: false}, 'app-1');
+      const qualifier2Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}, private: false}, 'app-1');
+      const qualifier3Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}, private: false}, 'app-1');
+      const qualifier4Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}, private: false}, 'app-1');
+      const qualifier5Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null, private: false}, 'app-1');
+      const qualifier6Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined, private: false}, 'app-1');
+      const qualifier7Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', private: false}, 'app-1');
 
       const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
 
       // Lookup using no qualifier filter
       Beans.get(ManifestService).lookupCapabilities$({type: 'view'}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[asteriskQualifierCapability, optionalQualifierCapability, exactQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability, qualifier4Capability, qualifier5Capability, qualifier6Capability, qualifier7Capability, qualifier8Capability, qualifier9Capability]]);
+      await expectEmissions(captor).toEqual([[exactQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability, qualifier4Capability, qualifier5Capability, qualifier6Capability, qualifier7Capability]]);
 
       // Lookup using qualifier filter: undefined
       Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: undefined}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[asteriskQualifierCapability, optionalQualifierCapability, exactQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability, qualifier4Capability, qualifier5Capability, qualifier6Capability, qualifier7Capability, qualifier8Capability, qualifier9Capability]]);
+      await expectEmissions(captor).toEqual([[exactQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability, qualifier4Capability, qualifier5Capability, qualifier6Capability, qualifier7Capability]]);
 
       // Lookup using qualifier filter: {'*': '*'}
       Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {'*': '*'}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[asteriskQualifierCapability, optionalQualifierCapability, exactQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability, qualifier4Capability, qualifier5Capability, qualifier6Capability, qualifier7Capability, qualifier8Capability, qualifier9Capability]]);
+      await expectEmissions(captor).toEqual([[exactQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability, qualifier4Capability, qualifier5Capability, qualifier6Capability, qualifier7Capability]]);
 
       // Lookup using qualifier filter: {}
       Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[qualifier6Capability, qualifier7Capability, qualifier8Capability, qualifier9Capability]]);
+      await expectEmissions(captor).toEqual([[qualifier4Capability, qualifier5Capability, qualifier6Capability, qualifier7Capability]]);
 
       // Lookup using qualifier filter: null
       Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: null}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[qualifier6Capability, qualifier7Capability, qualifier8Capability, qualifier9Capability]]);
+      await expectEmissions(captor).toEqual([[qualifier4Capability, qualifier5Capability, qualifier6Capability, qualifier7Capability]]);
 
-      // Lookup using qualifier filter: {entity: 'person', id: '*'}
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', id: '*'}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[asteriskQualifierCapability, optionalQualifierCapability, exactQualifierCapability]]);
-
-      // Lookup using qualifier filter: {entity: 'person', id: 'exact'}
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', id: 'exact'}}).subscribe(captor.reset());
+      // Lookup using qualifier filter: {entity: 'person', mode: '*'}
+      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', mode: '*'}}).subscribe(captor.reset());
       await expectEmissions(captor).toEqual([[exactQualifierCapability]]);
 
-      // Lookup using qualifier filter: {entity: 'person', id: '?'}
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', id: '?'}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[optionalQualifierCapability]]);
+      // Lookup using qualifier filter: {entity: 'person', mode: 'new'}
+      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', mode: 'new'}}).subscribe(captor.reset());
+      await expectEmissions(captor).toEqual([[exactQualifierCapability]]);
 
-      // Lookup using qualifier filter: {entity: 'person', id: '999'}
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', id: '999'}}).subscribe(captor.reset());
+      // Lookup using qualifier filter: {entity: 'person', mode: 'edit'}
+      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', mode: 'edit'}}).subscribe(captor.reset());
       await expectEmissions(captor).toEqual([[]]);
 
       // Lookup using qualifier filter: {entity: 'person'}
@@ -245,15 +221,15 @@ describe('ManifestService', () => {
 
       // Lookup using qualifier filter: {entity: 'person', other: 'property'}
       Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', other: 'property'}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[qualifier5Capability]]);
+      await expectEmissions(captor).toEqual([[qualifier3Capability]]);
 
-      // Lookup using qualifier filter: {entity: 'person', id: 'exact', other: 'property'}
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', id: '5', other: 'property'}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[]]);
+      // Lookup using qualifier filter: {entity: 'person', mode: 'new', other: 'property'}
+      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}).subscribe(captor.reset());
+      await expectEmissions(captor).toEqual([[qualifier2Capability]]);
 
       // Lookup using qualifier filter: {entity: 'person', '*': '*'}
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {'entity': 'person', '*': '*'}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[asteriskQualifierCapability, optionalQualifierCapability, exactQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability, qualifier4Capability, qualifier5Capability]]);
+      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', '*': '*'}}).subscribe(captor.reset());
+      await expectEmissions(captor).toEqual([[exactQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability]]);
     });
 
     it('should allow looking up public capabilities of another app (intention contains the asterisk wildcard (*))', async () => {
@@ -262,18 +238,14 @@ describe('ManifestService', () => {
         applications: [{symbolicName: 'app-1', manifestUrl: new ManifestFixture({name: 'App 1'}).serve()}],
       });
 
-      // Register intention in host-app: {entity: 'person', id: '*'}
-      Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '*'}}, 'host-app');
+      // Register intention in host-app: {entity: 'person', mode: '*'}
+      Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: '*'}}, 'host-app');
 
       // Register capabilities
-      const asteriskQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '*'}, private: false}, 'app-1');
-      const optionalQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '?'}, private: false}, 'app-1');
-      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'exact'}, private: false}, 'app-1');
+      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}, private: false}, 'app-1');
 
       await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}, private: false}, 'app-1');
-      await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '*', other: 'property'}, private: false}, 'app-1');
-      await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '?', other: 'property'}, private: false}, 'app-1');
-      await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'exact', other: 'property'}, private: false}, 'app-1');
+      await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}, private: false}, 'app-1');
       await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}, private: false}, 'app-1');
       await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}, private: false}, 'app-1');
       await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null, private: false}, 'app-1');
@@ -284,15 +256,15 @@ describe('ManifestService', () => {
 
       // Lookup using no qualifier filter
       Beans.get(ManifestService).lookupCapabilities$({type: 'view'}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[asteriskQualifierCapability, optionalQualifierCapability, exactQualifierCapability]]);
+      await expectEmissions(captor).toEqual([[exactQualifierCapability]]);
 
       // Lookup using qualifier filter: undefined
       Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: undefined}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[asteriskQualifierCapability, optionalQualifierCapability, exactQualifierCapability]]);
+      await expectEmissions(captor).toEqual([[exactQualifierCapability]]);
 
       // Lookup using qualifier filter: {'*': '*'}
       Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {'*': '*'}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[asteriskQualifierCapability, optionalQualifierCapability, exactQualifierCapability]]);
+      await expectEmissions(captor).toEqual([[exactQualifierCapability]]);
 
       // Lookup using qualifier filter: {}
       Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {}}).subscribe(captor.reset());
@@ -302,20 +274,16 @@ describe('ManifestService', () => {
       Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: null}).subscribe(captor.reset());
       await expectEmissions(captor).toEqual([[]]);
 
-      // Lookup using qualifier filter: {entity: 'person', id: '*'}
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', id: '*'}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[asteriskQualifierCapability, optionalQualifierCapability, exactQualifierCapability]]);
-
-      // Lookup using qualifier filter: {entity: 'person', id: 'exact'}
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', id: 'exact'}}).subscribe(captor.reset());
+      // Lookup using qualifier filter: {entity: 'person', mode: '*'}
+      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', mode: '*'}}).subscribe(captor.reset());
       await expectEmissions(captor).toEqual([[exactQualifierCapability]]);
 
-      // Lookup using qualifier filter: {entity: 'person', id: '?'}
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', id: '?'}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[optionalQualifierCapability]]);
+      // Lookup using qualifier filter: {entity: 'person', mode: 'new'}
+      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', mode: 'new'}}).subscribe(captor.reset());
+      await expectEmissions(captor).toEqual([[exactQualifierCapability]]);
 
-      // Lookup using qualifier filter: {entity: 'person', id: '999'}
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', id: '999'}}).subscribe(captor.reset());
+      // Lookup using qualifier filter: {entity: 'person', mode: 'edit'}
+      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', mode: 'edit'}}).subscribe(captor.reset());
       await expectEmissions(captor).toEqual([[]]);
 
       // Lookup using qualifier filter: {entity: 'person'}
@@ -326,13 +294,13 @@ describe('ManifestService', () => {
       Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', other: 'property'}}).subscribe(captor.reset());
       await expectEmissions(captor).toEqual([[]]);
 
-      // Lookup using qualifier filter: {entity: 'person', id: 'exact', other: 'property'}
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', id: '5', other: 'property'}}).subscribe(captor.reset());
+      // Lookup using qualifier filter: {entity: 'person', mode: 'new', other: 'property'}
+      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}).subscribe(captor.reset());
       await expectEmissions(captor).toEqual([[]]);
 
       // Lookup using qualifier filter: {entity: 'person', '*': '*'}
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {'entity': 'person', '*': '*'}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[asteriskQualifierCapability, optionalQualifierCapability, exactQualifierCapability]]);
+      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', '*': '*'}}).subscribe(captor.reset());
+      await expectEmissions(captor).toEqual([[exactQualifierCapability]]);
     });
 
     it('should allow looking up public capabilities of another app (intention is an exact qualifier)', async () => {
@@ -341,18 +309,14 @@ describe('ManifestService', () => {
         applications: [{symbolicName: 'app-1', manifestUrl: new ManifestFixture({name: 'App 1'}).serve()}],
       });
 
-      // Register intention in host-app: {entity: 'person', id: 'exact'}
-      Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: 'exact'}}, 'host-app');
+      // Register intention in host-app: {entity: 'person', mode: 'new'}
+      Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app');
 
       // Register capabilities
-      await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '*'}, private: false}, 'app-1');
-      await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '?'}, private: false}, 'app-1');
-      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'exact'}, private: false}, 'app-1');
+      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}, private: false}, 'app-1');
 
       await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}, private: false}, 'app-1');
-      await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '*', other: 'property'}, private: false}, 'app-1');
-      await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '?', other: 'property'}, private: false}, 'app-1');
-      await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'exact', other: 'property'}, private: false}, 'app-1');
+      await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}, private: false}, 'app-1');
       await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}, private: false}, 'app-1');
       await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}, private: false}, 'app-1');
       await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null, private: false}, 'app-1');
@@ -381,20 +345,16 @@ describe('ManifestService', () => {
       Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: null}).subscribe(captor.reset());
       await expectEmissions(captor).toEqual([[]]);
 
-      // Lookup using qualifier filter: {entity: 'person', id: '*'}
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', id: '*'}}).subscribe(captor.reset());
+      // Lookup using qualifier filter: {entity: 'person', mode: '*'}
+      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', mode: '*'}}).subscribe(captor.reset());
       await expectEmissions(captor).toEqual([[exactQualifierCapability]]);
 
-      // Lookup using qualifier filter: {entity: 'person', id: 'exact'}
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', id: 'exact'}}).subscribe(captor.reset());
+      // Lookup using qualifier filter: {entity: 'person', mode: 'new'}
+      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', mode: 'new'}}).subscribe(captor.reset());
       await expectEmissions(captor).toEqual([[exactQualifierCapability]]);
 
-      // Lookup using qualifier filter: {entity: 'person', id: '?'}
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', id: '?'}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[]]);
-
-      // Lookup using qualifier filter: {entity: 'person', id: '999'}
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', id: '999'}}).subscribe(captor.reset());
+      // Lookup using qualifier filter: {entity: 'person', mode: 'edit'}
+      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', mode: 'edit'}}).subscribe(captor.reset());
       await expectEmissions(captor).toEqual([[]]);
 
       // Lookup using qualifier filter: {entity: 'person'}
@@ -405,92 +365,13 @@ describe('ManifestService', () => {
       Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', other: 'property'}}).subscribe(captor.reset());
       await expectEmissions(captor).toEqual([[]]);
 
-      // Lookup using qualifier filter: {entity: 'person', id: 'exact', other: 'property'}
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', id: '5', other: 'property'}}).subscribe(captor.reset());
+      // Lookup using qualifier filter: {entity: 'person', mode: 'new', other: 'property'}
+      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}).subscribe(captor.reset());
       await expectEmissions(captor).toEqual([[]]);
 
       // Lookup using qualifier filter: {entity: 'person', '*': '*'}
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {'entity': 'person', '*': '*'}}).subscribe(captor.reset());
+      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', '*': '*'}}).subscribe(captor.reset());
       await expectEmissions(captor).toEqual([[exactQualifierCapability]]);
-    });
-
-    it('should allow looking up public capabilities of another app (intention contains the optional wildcard (?))', async () => {
-      await MicrofrontendPlatform.startHost({
-        host: {symbolicName: 'host-app'},
-        applications: [{symbolicName: 'app-1', manifestUrl: new ManifestFixture({name: 'App 1'}).serve()}],
-      });
-
-      // Register intention in host-app: {entity: 'person', id: '?'}
-      Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '?'}}, 'host-app');
-
-      // Register capabilities
-      const asteriskQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '*'}, private: false}, 'app-1');
-      const optionalQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '?'}, private: false}, 'app-1');
-      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'exact'}, private: false}, 'app-1');
-
-      const qualifier1Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}, private: false}, 'app-1');
-      await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '*', other: 'property'}, private: false}, 'app-1');
-      await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '?', other: 'property'}, private: false}, 'app-1');
-      await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'exact', other: 'property'}, private: false}, 'app-1');
-      await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}, private: false}, 'app-1');
-      await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}, private: false}, 'app-1');
-      await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null, private: false}, 'app-1');
-      await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined, private: false}, 'app-1');
-      await Beans.get(ManifestRegistry).registerCapability({type: 'view', private: false}, 'app-1');
-
-      const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
-
-      // Lookup using no qualifier filter
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view'}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[asteriskQualifierCapability, optionalQualifierCapability, exactQualifierCapability, qualifier1Capability]]);
-
-      // Lookup using qualifier filter: undefined
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: undefined}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[asteriskQualifierCapability, optionalQualifierCapability, exactQualifierCapability, qualifier1Capability]]);
-
-      // Lookup using qualifier filter: {'*': '*'}
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {'*': '*'}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[asteriskQualifierCapability, optionalQualifierCapability, exactQualifierCapability, qualifier1Capability]]);
-
-      // Lookup using qualifier filter: {}
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[]]);
-
-      // Lookup using qualifier filter: null
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: null}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[]]);
-
-      // Lookup using qualifier filter: {entity: 'person', id: '*'}
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', id: '*'}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[asteriskQualifierCapability, optionalQualifierCapability, exactQualifierCapability]]);
-
-      // Lookup using qualifier filter: {entity: 'person', id: 'exact'}
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', id: 'exact'}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[exactQualifierCapability]]);
-
-      // Lookup using qualifier filter: {entity: 'person', id: '?'}
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', id: '?'}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[optionalQualifierCapability]]);
-
-      // Lookup using qualifier filter: {entity: 'person', id: '999'}
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', id: '999'}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[]]);
-
-      // Lookup using qualifier filter: {entity: 'person'}
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person'}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[qualifier1Capability]]);
-
-      // Lookup using qualifier filter: {entity: 'person', other: 'property'}
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', other: 'property'}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[]]);
-
-      // Lookup using qualifier filter: {entity: 'person', id: 'exact', other: 'property'}
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', id: '5', other: 'property'}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[]]);
-
-      // Lookup using qualifier filter: {entity: 'person', '*': '*'}
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {'entity': 'person', '*': '*'}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[asteriskQualifierCapability, optionalQualifierCapability, exactQualifierCapability, qualifier1Capability]]);
     });
 
     it('should not allow looking up private capabilities of another app', async () => {
@@ -503,7 +384,7 @@ describe('ManifestService', () => {
       Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {'*': '*'}}, 'host-app');
 
       // Register capability
-      await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '*'}}, 'app-1');
+      await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'app-1');
 
       const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
 
@@ -522,7 +403,7 @@ describe('ManifestService', () => {
       Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {'*': '*'}}, 'host-app');
 
       // Register capability
-      const capabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '*'}}, 'app-1');
+      const capabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'app-1');
 
       const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
 
@@ -538,7 +419,7 @@ describe('ManifestService', () => {
       });
 
       // Register capability
-      await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '*'}}, 'app-1');
+      await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'app-1');
 
       const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
 
@@ -554,7 +435,7 @@ describe('ManifestService', () => {
       });
 
       // Register capability
-      const capabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '*'}, private: false}, 'app-1');
+      const capabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}, private: false}, 'app-1');
 
       const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
 
@@ -572,92 +453,82 @@ describe('ManifestService', () => {
       });
 
       // Register intentions in host-app
-      const asteriskQualifierHostIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '*'}}, 'host-app');
-      const optionalQualifierHostIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '?'}}, 'host-app');
-      const exactQualifierHostIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: 'exact'}}, 'host-app');
+      const asteriskQualifierHostIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: '*'}}, 'host-app');
+      const exactQualifierHostIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app');
       const qualifier1HostIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person'}}, 'host-app');
-      const qualifier2HostIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '*', other: 'property'}}, 'host-app');
-      const qualifier3HostIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '?', other: 'property'}}, 'host-app');
-      const qualifier4HostIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: 'exact', other: 'property'}}, 'host-app');
-      const qualifier5HostIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
-      const qualifier6HostIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {}}, 'host-app');
-      const qualifier7HostIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: null}, 'host-app');
-      const qualifier8HostIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: undefined}, 'host-app');
-      const qualifier9HostIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view'}, 'host-app');
+      const qualifier2HostIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: '*', other: 'property'}}, 'host-app');
+      const qualifier3HostIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app');
+      const qualifier4HostIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
+      const qualifier5HostIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {}}, 'host-app');
+      const qualifier6HostIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: null}, 'host-app');
+      const qualifier7HostIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: undefined}, 'host-app');
+      const qualifier8HostIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view'}, 'host-app');
 
       // Register intentions in app-1
-      const asteriskQualifierAppIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '*'}}, 'app-1');
-      const optionalQualifierAppIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '?'}}, 'app-1');
-      const exactQualifierAppIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: 'exact'}}, 'app-1');
+      const asteriskQualifierAppIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: '*'}}, 'app-1');
+      const exactQualifierAppIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'app-1');
       const qualifier1AppIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person'}}, 'app-1');
-      const qualifier2AppIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '*', other: 'property'}}, 'app-1');
-      const qualifier3AppIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '?', other: 'property'}}, 'app-1');
-      const qualifier4AppIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: 'exact', other: 'property'}}, 'app-1');
-      const qualifier5AppIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'app-1');
-      const qualifier6AppIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {}}, 'app-1');
-      const qualifier7AppIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: null}, 'app-1');
-      const qualifier8AppIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: undefined}, 'app-1');
-      const qualifier9AppIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view'}, 'app-1');
+      const qualifier2AppIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: '*', other: 'property'}}, 'app-1');
+      const qualifier3AppIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'app-1');
+      const qualifier4AppIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'app-1');
+      const qualifier5AppIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {}}, 'app-1');
+      const qualifier6AppIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: null}, 'app-1');
+      const qualifier7AppIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: undefined}, 'app-1');
+      const qualifier8AppIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view'}, 'app-1');
 
       const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
 
       // Lookup using no qualifier filter
       Beans.get(ManifestService).lookupIntentions$({type: 'view'}).subscribe(captor.reset());
       await expectEmissions(captor).toEqual([[
-        asteriskQualifierHostIntention, optionalQualifierHostIntention, exactQualifierHostIntention, qualifier1HostIntention, qualifier2HostIntention, qualifier3HostIntention, qualifier4HostIntention, qualifier5HostIntention, qualifier6HostIntention, qualifier7HostIntention, qualifier8HostIntention, qualifier9HostIntention,
-        asteriskQualifierAppIntention, optionalQualifierAppIntention, exactQualifierAppIntention, qualifier1AppIntention, qualifier2AppIntention, qualifier3AppIntention, qualifier4AppIntention, qualifier5AppIntention, qualifier6AppIntention, qualifier7AppIntention, qualifier8AppIntention, qualifier9AppIntention,
+        asteriskQualifierHostIntention, exactQualifierHostIntention, qualifier1HostIntention, qualifier2HostIntention, qualifier3HostIntention, qualifier4HostIntention, qualifier5HostIntention, qualifier6HostIntention, qualifier7HostIntention, qualifier8HostIntention,
+        asteriskQualifierAppIntention, exactQualifierAppIntention, qualifier1AppIntention, qualifier2AppIntention, qualifier3AppIntention, qualifier4AppIntention, qualifier5AppIntention, qualifier6AppIntention, qualifier7AppIntention, qualifier8AppIntention,
       ]]);
 
       // Lookup using qualifier filter: undefined
       Beans.get(ManifestService).lookupIntentions$({type: 'view', qualifier: undefined}).subscribe(captor.reset());
       await expectEmissions(captor).toEqual([[
-        asteriskQualifierHostIntention, optionalQualifierHostIntention, exactQualifierHostIntention, qualifier1HostIntention, qualifier2HostIntention, qualifier3HostIntention, qualifier4HostIntention, qualifier5HostIntention, qualifier6HostIntention, qualifier7HostIntention, qualifier8HostIntention, qualifier9HostIntention,
-        asteriskQualifierAppIntention, optionalQualifierAppIntention, exactQualifierAppIntention, qualifier1AppIntention, qualifier2AppIntention, qualifier3AppIntention, qualifier4AppIntention, qualifier5AppIntention, qualifier6AppIntention, qualifier7AppIntention, qualifier8AppIntention, qualifier9AppIntention,
+        asteriskQualifierHostIntention, exactQualifierHostIntention, qualifier1HostIntention, qualifier2HostIntention, qualifier3HostIntention, qualifier4HostIntention, qualifier5HostIntention, qualifier6HostIntention, qualifier7HostIntention, qualifier8HostIntention,
+        asteriskQualifierAppIntention, exactQualifierAppIntention, qualifier1AppIntention, qualifier2AppIntention, qualifier3AppIntention, qualifier4AppIntention, qualifier5AppIntention, qualifier6AppIntention, qualifier7AppIntention, qualifier8AppIntention,
       ]]);
 
       // Lookup using qualifier filter: {'*': '*'}
       Beans.get(ManifestService).lookupIntentions$({type: 'view', qualifier: {'*': '*'}}).subscribe(captor.reset());
       await expectEmissions(captor).toEqual([[
-        asteriskQualifierHostIntention, optionalQualifierHostIntention, exactQualifierHostIntention, qualifier1HostIntention, qualifier2HostIntention, qualifier3HostIntention, qualifier4HostIntention, qualifier5HostIntention, qualifier6HostIntention, qualifier7HostIntention, qualifier8HostIntention, qualifier9HostIntention,
-        asteriskQualifierAppIntention, optionalQualifierAppIntention, exactQualifierAppIntention, qualifier1AppIntention, qualifier2AppIntention, qualifier3AppIntention, qualifier4AppIntention, qualifier5AppIntention, qualifier6AppIntention, qualifier7AppIntention, qualifier8AppIntention, qualifier9AppIntention,
+        asteriskQualifierHostIntention, exactQualifierHostIntention, qualifier1HostIntention, qualifier2HostIntention, qualifier3HostIntention, qualifier4HostIntention, qualifier5HostIntention, qualifier6HostIntention, qualifier7HostIntention, qualifier8HostIntention,
+        asteriskQualifierAppIntention, exactQualifierAppIntention, qualifier1AppIntention, qualifier2AppIntention, qualifier3AppIntention, qualifier4AppIntention, qualifier5AppIntention, qualifier6AppIntention, qualifier7AppIntention, qualifier8AppIntention,
       ]]);
 
       // Lookup using qualifier filter: {}
       Beans.get(ManifestService).lookupIntentions$({type: 'view', qualifier: {}}).subscribe(captor.reset());
       await expectEmissions(captor).toEqual([[
-        qualifier6HostIntention, qualifier7HostIntention, qualifier8HostIntention, qualifier9HostIntention,
-        qualifier6AppIntention, qualifier7AppIntention, qualifier8AppIntention, qualifier9AppIntention,
+        qualifier5HostIntention, qualifier6HostIntention, qualifier7HostIntention, qualifier8HostIntention,
+        qualifier5AppIntention, qualifier6AppIntention, qualifier7AppIntention, qualifier8AppIntention,
       ]]);
 
       // Lookup using qualifier filter: null
       Beans.get(ManifestService).lookupIntentions$({type: 'view', qualifier: null}).subscribe(captor.reset());
       await expectEmissions(captor).toEqual([[
-        qualifier6HostIntention, qualifier7HostIntention, qualifier8HostIntention, qualifier9HostIntention,
-        qualifier6AppIntention, qualifier7AppIntention, qualifier8AppIntention, qualifier9AppIntention,
+        qualifier5HostIntention, qualifier6HostIntention, qualifier7HostIntention, qualifier8HostIntention,
+        qualifier5AppIntention, qualifier6AppIntention, qualifier7AppIntention, qualifier8AppIntention,
       ]]);
 
-      // Lookup using qualifier filter: {entity: 'person', id: '*'}
-      Beans.get(ManifestService).lookupIntentions$({type: 'view', qualifier: {entity: 'person', id: '*'}}).subscribe(captor.reset());
+      // Lookup using qualifier filter: {entity: 'person', mode: '*'}
+      Beans.get(ManifestService).lookupIntentions$({type: 'view', qualifier: {entity: 'person', mode: '*'}}).subscribe(captor.reset());
       await expectEmissions(captor).toEqual([[
-        asteriskQualifierHostIntention, optionalQualifierHostIntention, exactQualifierHostIntention,
-        asteriskQualifierAppIntention, optionalQualifierAppIntention, exactQualifierAppIntention,
+        asteriskQualifierHostIntention, exactQualifierHostIntention,
+        asteriskQualifierAppIntention, exactQualifierAppIntention,
       ]]);
 
-      // Lookup using qualifier filter: {entity: 'person', id: 'exact'}
-      Beans.get(ManifestService).lookupIntentions$({type: 'view', qualifier: {entity: 'person', id: 'exact'}}).subscribe(captor.reset());
+      // Lookup using qualifier filter: {entity: 'person', mode: 'new'}
+      Beans.get(ManifestService).lookupIntentions$({type: 'view', qualifier: {entity: 'person', mode: 'new'}}).subscribe(captor.reset());
       await expectEmissions(captor).toEqual([[
         exactQualifierHostIntention,
         exactQualifierAppIntention,
       ]]);
 
-      Beans.get(ManifestService).lookupIntentions$({type: 'view', qualifier: {entity: 'person', id: '?'}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[
-        optionalQualifierHostIntention,
-        optionalQualifierAppIntention,
-      ]]);
-
-      // Lookup using qualifier filter: {entity: 'person', id: '999'}
-      Beans.get(ManifestService).lookupIntentions$({type: 'view', qualifier: {entity: 'person', id: '999'}}).subscribe(captor.reset());
+      // Lookup using qualifier filter: {entity: 'person', mode: 'edit'}
+      Beans.get(ManifestService).lookupIntentions$({type: 'view', qualifier: {entity: 'person', mode: 'edit'}}).subscribe(captor.reset());
       await expectEmissions(captor).toEqual([[]]);
 
       // Lookup using qualifier filter: {entity: 'person'}
@@ -670,19 +541,22 @@ describe('ManifestService', () => {
       // Lookup using qualifier filter: {entity: 'person', other: 'property'}
       Beans.get(ManifestService).lookupIntentions$({type: 'view', qualifier: {entity: 'person', other: 'property'}}).subscribe(captor.reset());
       await expectEmissions(captor).toEqual([[
-        qualifier5HostIntention,
-        qualifier5AppIntention,
+        qualifier4HostIntention,
+        qualifier4AppIntention,
       ]]);
 
-      // Lookup using qualifier filter: {entity: 'person', id: 'exact', other: 'property'}
-      Beans.get(ManifestService).lookupIntentions$({type: 'view', qualifier: {entity: 'person', id: '5', other: 'property'}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[]]);
+      // Lookup using qualifier filter: {entity: 'person', mode: 'new', other: 'property'}
+      Beans.get(ManifestService).lookupIntentions$({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}).subscribe(captor.reset());
+      await expectEmissions(captor).toEqual([[
+        qualifier3HostIntention,
+        qualifier3AppIntention,
+      ]]);
 
       // Lookup using qualifier filter: {entity: 'person', '*': '*'}
-      Beans.get(ManifestService).lookupIntentions$({type: 'view', qualifier: {'entity': 'person', '*': '*'}}).subscribe(captor.reset());
+      Beans.get(ManifestService).lookupIntentions$({type: 'view', qualifier: {entity: 'person', '*': '*'}}).subscribe(captor.reset());
       await expectEmissions(captor).toEqual([[
-        asteriskQualifierHostIntention, optionalQualifierHostIntention, exactQualifierHostIntention, qualifier1HostIntention, qualifier2HostIntention, qualifier3HostIntention, qualifier4HostIntention, qualifier5HostIntention,
-        asteriskQualifierAppIntention, optionalQualifierAppIntention, exactQualifierAppIntention, qualifier1AppIntention, qualifier2AppIntention, qualifier3AppIntention, qualifier4AppIntention, qualifier5AppIntention,
+        asteriskQualifierHostIntention, exactQualifierHostIntention, qualifier1HostIntention, qualifier2HostIntention, qualifier3HostIntention, qualifier4HostIntention,
+        asteriskQualifierAppIntention, exactQualifierAppIntention, qualifier1AppIntention, qualifier2AppIntention, qualifier3AppIntention, qualifier4AppIntention,
       ]]);
     });
   });
@@ -695,36 +569,32 @@ describe('ManifestService', () => {
       });
 
       // Register capabilities
-      const asteriskQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '*'}}, 'host-app');
-      const optionalQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '?'}}, 'host-app');
-      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'exact'}}, 'host-app');
+      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app');
 
       const qualifier1Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'host-app');
-      const qualifier2Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '*', other: 'property'}}, 'host-app');
-      const qualifier3Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '?', other: 'property'}}, 'host-app');
-      const qualifier4Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'exact', other: 'property'}}, 'host-app');
-      const qualifier5Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
-      const qualifier6Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app');
-      const qualifier7Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null}, 'host-app');
-      const qualifier8Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app');
-      const qualifier9Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app');
+      const qualifier2Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app');
+      const qualifier3Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
+      const qualifier4Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app');
+      const qualifier5Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null}, 'host-app');
+      const qualifier6Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app');
+      const qualifier7Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app');
 
       const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
 
       // PRE-CONDITION: Verify all capabilities to be registered
       Beans.get(ManifestService).lookupCapabilities$({type: 'view'}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[asteriskQualifierCapability, optionalQualifierCapability, exactQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability, qualifier4Capability, qualifier5Capability, qualifier6Capability, qualifier7Capability, qualifier8Capability, qualifier9Capability]]);
+      await expectEmissions(captor).toEqual([[exactQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability, qualifier4Capability, qualifier5Capability, qualifier6Capability, qualifier7Capability]]);
 
-      // Remove capabilities using following qualifier: {entity: 'person', id: 'exact'}
-      await Beans.get(ManifestService).unregisterCapabilities({type: 'view', qualifier: {entity: 'person', id: 'exact'}});
+      // Remove capabilities using following qualifier: {entity: 'person', mode: 'new'}
+      await Beans.get(ManifestService).unregisterCapabilities({type: 'view', qualifier: {entity: 'person', mode: 'new'}});
 
       // Expect removal and lookup to be symmetrical, i.e., a subsequent lookup with the same qualifier as used for the removal should return nothing
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', id: 'exact'}}).subscribe(captor.reset());
+      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', mode: 'new'}}).subscribe(captor.reset());
       await expectEmissions(captor).toEqual([[]]);
 
       // Expect capabilities
       Beans.get(ManifestService).lookupCapabilities$({type: 'view'}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[asteriskQualifierCapability, optionalQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability, qualifier4Capability, qualifier5Capability, qualifier6Capability, qualifier7Capability, qualifier8Capability, qualifier9Capability]]);
+      await expectEmissions(captor).toEqual([[qualifier1Capability, qualifier2Capability, qualifier3Capability, qualifier4Capability, qualifier5Capability, qualifier6Capability, qualifier7Capability]]);
     });
 
     it('should allow removing capabilities using the asterisk wildcard (*) in the qualifier', async () => {
@@ -734,75 +604,32 @@ describe('ManifestService', () => {
       });
 
       // Register capabilities
-      const asteriskQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '*'}}, 'host-app');
-      const optionalQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '?'}}, 'host-app');
-      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'exact'}}, 'host-app');
+      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app');
 
       const qualifier1Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'host-app');
-      const qualifier2Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '*', other: 'property'}}, 'host-app');
-      const qualifier3Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '?', other: 'property'}}, 'host-app');
-      const qualifier4Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'exact', other: 'property'}}, 'host-app');
-      const qualifier5Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
-      const qualifier6Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app');
-      const qualifier7Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null}, 'host-app');
-      const qualifier8Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app');
-      const qualifier9Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app');
+      const qualifier2Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app');
+      const qualifier3Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
+      const qualifier4Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app');
+      const qualifier5Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null}, 'host-app');
+      const qualifier6Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app');
+      const qualifier7Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app');
 
       const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
 
       // PRE-CONDITION: Verify all capabilities to be registered
       Beans.get(ManifestService).lookupCapabilities$({type: 'view'}).subscribe(captor);
-      await expectEmissions(captor).toEqual([[asteriskQualifierCapability, optionalQualifierCapability, exactQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability, qualifier4Capability, qualifier5Capability, qualifier6Capability, qualifier7Capability, qualifier8Capability, qualifier9Capability]]);
+      await expectEmissions(captor).toEqual([[exactQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability, qualifier4Capability, qualifier5Capability, qualifier6Capability, qualifier7Capability]]);
 
-      // Remove capabilities using following qualifier: {entity: 'person', id: '*'}
-      await Beans.get(ManifestService).unregisterCapabilities({type: 'view', qualifier: {entity: 'person', id: '*'}});
+      // Remove capabilities using following qualifier: {entity: 'person', mode: '*'}
+      await Beans.get(ManifestService).unregisterCapabilities({type: 'view', qualifier: {entity: 'person', mode: '*'}});
 
       // Expect removal and lookup to be symmetrical, i.e., a subsequent lookup with the same qualifier as used for the removal should return nothing
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', id: '*'}}).subscribe(captor.reset());
+      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', mode: '*'}}).subscribe(captor.reset());
       await expectEmissions(captor).toEqual([[]]);
 
       // Expect capabilities
       Beans.get(ManifestService).lookupCapabilities$({type: 'view'}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[qualifier1Capability, qualifier2Capability, qualifier3Capability, qualifier4Capability, qualifier5Capability, qualifier6Capability, qualifier7Capability, qualifier8Capability, qualifier9Capability]]);
-    });
-
-    it('should interpret the question mark (?) as value (and not as wildcard) when removing capabilities', async () => {
-      await MicrofrontendPlatform.startHost({
-        host: {symbolicName: 'host-app'},
-        applications: [],
-      });
-
-      // Register capabilities
-      const asteriskQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '*'}}, 'host-app');
-      const optionalQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '?'}}, 'host-app');
-      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'exact'}}, 'host-app');
-
-      const qualifier1Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'host-app');
-      const qualifier2Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '*', other: 'property'}}, 'host-app');
-      const qualifier3Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '?', other: 'property'}}, 'host-app');
-      const qualifier4Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'exact', other: 'property'}}, 'host-app');
-      const qualifier5Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
-      const qualifier6Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app');
-      const qualifier7Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null}, 'host-app');
-      const qualifier8Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app');
-      const qualifier9Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app');
-
-      const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
-
-      // PRE-CONDITION: Verify all capabilities to be registered
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view'}).subscribe(captor);
-      await expectEmissions(captor).toEqual([[asteriskQualifierCapability, optionalQualifierCapability, exactQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability, qualifier4Capability, qualifier5Capability, qualifier6Capability, qualifier7Capability, qualifier8Capability, qualifier9Capability]]);
-
-      // Remove capabilities using following qualifier: {entity: 'person', id: '?'}
-      await Beans.get(ManifestService).unregisterCapabilities({type: 'view', qualifier: {entity: 'person', id: '?'}});
-
-      // Expect removal and lookup to be symmetrical, i.e., a subsequent lookup with the same qualifier as used for the removal should return nothing
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', id: '?'}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[]]);
-
-      // Expect capabilities
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view'}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[asteriskQualifierCapability, exactQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability, qualifier4Capability, qualifier5Capability, qualifier6Capability, qualifier7Capability, qualifier8Capability, qualifier9Capability]]);
+      await expectEmissions(captor).toEqual([[qualifier1Capability, qualifier2Capability, qualifier3Capability, qualifier4Capability, qualifier5Capability, qualifier6Capability, qualifier7Capability]]);
     });
 
     it('should allow removing capabilities using an exact qualifier together with the any-more wildcard (**) ', async () => {
@@ -812,75 +639,32 @@ describe('ManifestService', () => {
       });
 
       // Register capabilities
-      const asteriskQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '*'}}, 'host-app');
-      const optionalQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '?'}}, 'host-app');
-      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'exact'}}, 'host-app');
+      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app');
 
       const qualifier1Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'host-app');
-      const qualifier2Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '*', other: 'property'}}, 'host-app');
-      const qualifier3Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '?', other: 'property'}}, 'host-app');
-      const qualifier4Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'exact', other: 'property'}}, 'host-app');
-      const qualifier5Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
-      const qualifier6Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app');
-      const qualifier7Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null}, 'host-app');
-      const qualifier8Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app');
-      const qualifier9Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app');
+      const qualifier2Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app');
+      const qualifier3Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
+      const qualifier4Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app');
+      const qualifier5Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null}, 'host-app');
+      const qualifier6Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app');
+      const qualifier7Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app');
 
       const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
 
       // PRE-CONDITION: Verify all capabilities to be registered
       Beans.get(ManifestService).lookupCapabilities$({type: 'view'}).subscribe(captor);
-      await expectEmissions(captor).toEqual([[asteriskQualifierCapability, optionalQualifierCapability, exactQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability, qualifier4Capability, qualifier5Capability, qualifier6Capability, qualifier7Capability, qualifier8Capability, qualifier9Capability]]);
+      await expectEmissions(captor).toEqual([[exactQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability, qualifier4Capability, qualifier5Capability, qualifier6Capability, qualifier7Capability]]);
 
-      // Remove capabilities using following qualifier: {entity: 'person', id: 'exact', '*': '*'}
-      await Beans.get(ManifestService).unregisterCapabilities({type: 'view', qualifier: {'entity': 'person', 'id': 'exact', '*': '*'}});
+      // Remove capabilities using following qualifier: {entity: 'person', mode: 'new', '*': '*'}
+      await Beans.get(ManifestService).unregisterCapabilities({type: 'view', qualifier: {entity: 'person', mode: 'new', '*': '*'}});
 
       // Expect removal and lookup to be symmetrical, i.e., a subsequent lookup with the same qualifier as used for the removal should return nothing
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {'entity': 'person', 'id': 'exact', '*': '*'}}).subscribe(captor.reset());
+      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', mode: 'new', '*': '*'}}).subscribe(captor.reset());
       await expectEmissions(captor).toEqual([[]]);
 
       // Expect capabilities
       Beans.get(ManifestService).lookupCapabilities$({type: 'view'}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[asteriskQualifierCapability, optionalQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability, qualifier5Capability, qualifier6Capability, qualifier7Capability, qualifier8Capability, qualifier9Capability]]);
-    });
-
-    it('should interpret the question mark (?) as value and not as wildcard when removing capabilities using the any-more wildcard (**)', async () => {
-      await MicrofrontendPlatform.startHost({
-        host: {symbolicName: 'host-app'},
-        applications: [],
-      });
-
-      // Register capabilities
-      const asteriskQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '*'}}, 'host-app');
-      const optionalQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '?'}}, 'host-app');
-      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'exact'}}, 'host-app');
-
-      const qualifier1Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'host-app');
-      const qualifier2Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '*', other: 'property'}}, 'host-app');
-      const qualifier3Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '?', other: 'property'}}, 'host-app');
-      const qualifier4Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'exact', other: 'property'}}, 'host-app');
-      const qualifier5Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
-      const qualifier6Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app');
-      const qualifier7Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null}, 'host-app');
-      const qualifier8Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app');
-      const qualifier9Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app');
-
-      const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
-
-      // PRE-CONDITION: Verify all capabilities to be registered
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view'}).subscribe(captor);
-      await expectEmissions(captor).toEqual([[asteriskQualifierCapability, optionalQualifierCapability, exactQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability, qualifier4Capability, qualifier5Capability, qualifier6Capability, qualifier7Capability, qualifier8Capability, qualifier9Capability]]);
-
-      // Remove capabilities using following qualifier: {entity: 'person', id: '?', '*': '*'}
-      await Beans.get(ManifestService).unregisterCapabilities({type: 'view', qualifier: {'entity': 'person', 'id': '?', '*': '*'}});
-
-      // Expect removal and lookup to be symmetrical, i.e., a subsequent lookup with the same qualifier as used for the removal should return nothing
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {'entity': 'person', 'id': '?', '*': '*'}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[]]);
-
-      // Expect capabilities
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view'}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[asteriskQualifierCapability, exactQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier4Capability, qualifier5Capability, qualifier6Capability, qualifier7Capability, qualifier8Capability, qualifier9Capability]]);
+      await expectEmissions(captor).toEqual([[qualifier1Capability, qualifier3Capability, qualifier4Capability, qualifier5Capability, qualifier6Capability, qualifier7Capability]]);
     });
 
     it('should allow removing capabilities using the asterisk wildcard (*) together with the any-more wildcard (**) ', async () => {
@@ -890,36 +674,32 @@ describe('ManifestService', () => {
       });
 
       // Register capabilities
-      const asteriskQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '*'}}, 'host-app');
-      const optionalQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '?'}}, 'host-app');
-      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'exact'}}, 'host-app');
+      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app');
 
       const qualifier1Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'host-app');
-      const qualifier2Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '*', other: 'property'}}, 'host-app');
-      const qualifier3Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '?', other: 'property'}}, 'host-app');
-      const qualifier4Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'exact', other: 'property'}}, 'host-app');
-      const qualifier5Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
-      const qualifier6Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app');
-      const qualifier7Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null}, 'host-app');
-      const qualifier8Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app');
-      const qualifier9Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app');
+      const qualifier2Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app');
+      const qualifier3Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
+      const qualifier4Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app');
+      const qualifier5Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null}, 'host-app');
+      const qualifier6Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app');
+      const qualifier7Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app');
 
       const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
 
       // PRE-CONDITION: Verify all capabilities to be registered
       Beans.get(ManifestService).lookupCapabilities$({type: 'view'}).subscribe(captor);
-      await expectEmissions(captor).toEqual([[asteriskQualifierCapability, optionalQualifierCapability, exactQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability, qualifier4Capability, qualifier5Capability, qualifier6Capability, qualifier7Capability, qualifier8Capability, qualifier9Capability]]);
+      await expectEmissions(captor).toEqual([[exactQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability, qualifier4Capability, qualifier5Capability, qualifier6Capability, qualifier7Capability]]);
 
-      // Remove capabilities using following qualifier: {entity: 'person', id: '*', '*': '*'}
-      await Beans.get(ManifestService).unregisterCapabilities({type: 'view', qualifier: {'entity': 'person', 'id': '*', '*': '*'}});
+      // Remove capabilities using following qualifier: {entity: 'person', mode: '*', '*': '*'}
+      await Beans.get(ManifestService).unregisterCapabilities({type: 'view', qualifier: {entity: 'person', mode: '*', '*': '*'}});
 
       // Expect removal and lookup to be symmetrical, i.e., a subsequent lookup with the same qualifier as used for the removal should return nothing
-      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {'entity': 'person', 'id': '*', '*': '*'}}).subscribe(captor.reset());
+      Beans.get(ManifestService).lookupCapabilities$({type: 'view', qualifier: {entity: 'person', mode: '*', '*': '*'}}).subscribe(captor.reset());
       await expectEmissions(captor).toEqual([[]]);
 
       // Expect capabilities
       Beans.get(ManifestService).lookupCapabilities$({type: 'view'}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[qualifier1Capability, qualifier5Capability, qualifier6Capability, qualifier7Capability, qualifier8Capability, qualifier9Capability]]);
+      await expectEmissions(captor).toEqual([[qualifier1Capability, qualifier3Capability, qualifier4Capability, qualifier5Capability, qualifier6Capability, qualifier7Capability]]);
     });
 
     it('should allow removing all capabilities using the any-more wildcard (**)', async () => {
@@ -929,25 +709,21 @@ describe('ManifestService', () => {
       });
 
       // Register capabilities
-      const asteriskQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '*'}}, 'host-app');
-      const optionalQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '?'}}, 'host-app');
-      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'exact'}}, 'host-app');
+      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app');
 
       const qualifier1Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'host-app');
-      const qualifier2Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '*', other: 'property'}}, 'host-app');
-      const qualifier3Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '?', other: 'property'}}, 'host-app');
-      const qualifier4Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'exact', other: 'property'}}, 'host-app');
-      const qualifier5Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
-      const qualifier6Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app');
-      const qualifier7Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null}, 'host-app');
-      const qualifier8Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app');
-      const qualifier9Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app');
+      const qualifier2Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app');
+      const qualifier3Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
+      const qualifier4Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app');
+      const qualifier5Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null}, 'host-app');
+      const qualifier6Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app');
+      const qualifier7Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app');
 
       const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
 
       // PRE-CONDITION: Verify all capabilities to be registered
       Beans.get(ManifestService).lookupCapabilities$({type: 'view'}).subscribe(captor);
-      await expectEmissions(captor).toEqual([[asteriskQualifierCapability, optionalQualifierCapability, exactQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability, qualifier4Capability, qualifier5Capability, qualifier6Capability, qualifier7Capability, qualifier8Capability, qualifier9Capability]]);
+      await expectEmissions(captor).toEqual([[exactQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability, qualifier4Capability, qualifier5Capability, qualifier6Capability, qualifier7Capability]]);
 
       // Remove capabilities using following qualifier: {entity: '*': '*'}
       await Beans.get(ManifestService).unregisterCapabilities({type: 'view', qualifier: {'*': '*'}});
@@ -964,25 +740,21 @@ describe('ManifestService', () => {
       });
 
       // Register capabilities
-      const asteriskQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '*'}}, 'host-app');
-      const optionalQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '?'}}, 'host-app');
-      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'exact'}}, 'host-app');
+      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app');
 
       const qualifier1Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'host-app');
-      const qualifier2Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '*', other: 'property'}}, 'host-app');
-      const qualifier3Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '?', other: 'property'}}, 'host-app');
-      const qualifier4Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'exact', other: 'property'}}, 'host-app');
-      const qualifier5Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
-      const qualifier6Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app');
-      const qualifier7Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null}, 'host-app');
-      const qualifier8Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app');
-      const qualifier9Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app');
+      const qualifier2Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app');
+      const qualifier3Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
+      const qualifier4Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app');
+      const qualifier5Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null}, 'host-app');
+      const qualifier6Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app');
+      const qualifier7Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app');
 
       const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
 
       // PRE-CONDITION: Verify all capabilities to be registered
       Beans.get(ManifestService).lookupCapabilities$({type: 'view'}).subscribe(captor);
-      await expectEmissions(captor).toEqual([[asteriskQualifierCapability, optionalQualifierCapability, exactQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability, qualifier4Capability, qualifier5Capability, qualifier6Capability, qualifier7Capability, qualifier8Capability, qualifier9Capability]]);
+      await expectEmissions(captor).toEqual([[exactQualifierCapability, qualifier1Capability, qualifier2Capability, qualifier3Capability, qualifier4Capability, qualifier5Capability, qualifier6Capability, qualifier7Capability]]);
 
       // Remove capabilities using no qualifier
       await Beans.get(ManifestService).unregisterCapabilities({type: 'view'});
@@ -998,8 +770,8 @@ describe('ManifestService', () => {
         applications: [{symbolicName: 'app-1', manifestUrl: new ManifestFixture({name: 'App 1'}).serve()}],
       });
 
-      const capabilityIdHostApp = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '*'}, private: false}, 'host-app');
-      const capabilityIdApp1 = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '*'}, private: false}, 'app-1');
+      const capabilityIdHostApp = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}, private: false}, 'host-app');
+      const capabilityIdApp1 = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}, private: false}, 'app-1');
 
       // Unregister all capabilities of the host app.
       await Beans.get(ManifestService).unregisterCapabilities();
@@ -1023,37 +795,35 @@ describe('ManifestService', () => {
       });
 
       // Register intentions
-      const asteriskQualifierIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '*'}}, 'host-app');
-      const optionalQualifierIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '?'}}, 'host-app');
-      const exactQualifierIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: 'exact'}}, 'host-app');
+      const asteriskQualifierIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: '*'}}, 'host-app');
+      const exactQualifierIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app');
 
       const qualifier1Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person'}}, 'host-app');
-      const qualifier2Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '*', other: 'property'}}, 'host-app');
-      const qualifier3Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '?', other: 'property'}}, 'host-app');
-      const qualifier4Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: 'exact', other: 'property'}}, 'host-app');
-      const qualifier5Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
-      const qualifier6Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {}}, 'host-app');
-      const qualifier7Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: null}, 'host-app');
-      const qualifier8Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: undefined}, 'host-app');
-      const qualifier9Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view'}, 'host-app');
-      const qualifier10Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {'*': '*'}}, 'host-app');
+      const qualifier2Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: '*', other: 'property'}}, 'host-app');
+      const qualifier3Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app');
+      const qualifier4Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
+      const qualifier5Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {}}, 'host-app');
+      const qualifier6Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: null}, 'host-app');
+      const qualifier7Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: undefined}, 'host-app');
+      const qualifier8Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view'}, 'host-app');
+      const qualifier9Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {'*': '*'}}, 'host-app');
 
       const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
 
       // PRE-CONDITION: Verify all intentions to be registered
       Beans.get(ManifestService).lookupIntentions$({type: 'view'}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[asteriskQualifierIntention, optionalQualifierIntention, exactQualifierIntention, qualifier1Intention, qualifier2Intention, qualifier3Intention, qualifier4Intention, qualifier5Intention, qualifier6Intention, qualifier7Intention, qualifier8Intention, qualifier9Intention, qualifier10Intention]]);
+      await expectEmissions(captor).toEqual([[asteriskQualifierIntention, exactQualifierIntention, qualifier1Intention, qualifier2Intention, qualifier3Intention, qualifier4Intention, qualifier5Intention, qualifier6Intention, qualifier7Intention, qualifier8Intention, qualifier9Intention]]);
 
-      // Remove intentions using following qualifier: {entity: 'person', id: 'exact'}
-      await Beans.get(ManifestService).unregisterIntentions({type: 'view', qualifier: {entity: 'person', id: 'exact'}});
+      // Remove intentions using following qualifier: {entity: 'person', mode: 'new'}
+      await Beans.get(ManifestService).unregisterIntentions({type: 'view', qualifier: {entity: 'person', mode: 'new'}});
 
       // Expect removal and lookup to be symmetrical, i.e., a subsequent lookup with the same qualifier as used for the removal should return nothing
-      Beans.get(ManifestService).lookupIntentions$({type: 'view', qualifier: {entity: 'person', id: 'exact'}}).subscribe(captor.reset());
+      Beans.get(ManifestService).lookupIntentions$({type: 'view', qualifier: {entity: 'person', mode: 'new'}}).subscribe(captor.reset());
       await expectEmissions(captor).toEqual([[]]);
 
       // Expect intentions
       Beans.get(ManifestService).lookupIntentions$({type: 'view'}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[asteriskQualifierIntention, optionalQualifierIntention, qualifier1Intention, qualifier2Intention, qualifier3Intention, qualifier4Intention, qualifier5Intention, qualifier6Intention, qualifier7Intention, qualifier8Intention, qualifier9Intention, qualifier10Intention]]);
+      await expectEmissions(captor).toEqual([[asteriskQualifierIntention, qualifier1Intention, qualifier2Intention, qualifier3Intention, qualifier4Intention, qualifier5Intention, qualifier6Intention, qualifier7Intention, qualifier8Intention, qualifier9Intention]]);
     });
 
     it('should allow removing intentions using the asterisk wildcard (*) in the qualifier', async () => {
@@ -1063,78 +833,36 @@ describe('ManifestService', () => {
       });
 
       // Register intentions
-      const asteriskQualifierIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '*'}}, 'host-app');
-      const optionalQualifierIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '?'}}, 'host-app');
-      const exactQualifierIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: 'exact'}}, 'host-app');
+      const asteriskQualifierIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: '*'}}, 'host-app');
+      const exactQualifierIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app');
 
       const qualifier1Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person'}}, 'host-app');
-      const qualifier2Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '*', other: 'property'}}, 'host-app');
-      const qualifier3Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '?', other: 'property'}}, 'host-app');
-      const qualifier4Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: 'exact', other: 'property'}}, 'host-app');
-      const qualifier5Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
-      const qualifier6Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {}}, 'host-app');
-      const qualifier7Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: null}, 'host-app');
-      const qualifier8Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: undefined}, 'host-app');
-      const qualifier9Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view'}, 'host-app');
-      const qualifier10Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {'*': '*'}}, 'host-app');
+      const qualifier2Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: '*', other: 'property'}}, 'host-app');
+      const qualifier3Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app');
+      const qualifier4Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
+      const qualifier5Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {}}, 'host-app');
+      const qualifier6Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: null}, 'host-app');
+      const qualifier7Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: undefined}, 'host-app');
+      const qualifier8Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view'}, 'host-app');
+      const qualifier9Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {'*': '*'}}, 'host-app');
 
       const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
 
       // PRE-CONDITION: Verify all intentions to be registered
       Beans.get(ManifestService).lookupIntentions$({type: 'view'}).subscribe(captor);
-      await expectEmissions(captor).toEqual([[asteriskQualifierIntention, optionalQualifierIntention, exactQualifierIntention, qualifier1Intention, qualifier2Intention, qualifier3Intention, qualifier4Intention, qualifier5Intention, qualifier6Intention, qualifier7Intention, qualifier8Intention, qualifier9Intention, qualifier10Intention]]);
+      await expectEmissions(captor).toEqual([[asteriskQualifierIntention, exactQualifierIntention, qualifier1Intention, qualifier2Intention, qualifier3Intention, qualifier4Intention, qualifier5Intention, qualifier6Intention, qualifier7Intention, qualifier8Intention, qualifier9Intention]]);
 
-      // Remove intentions using following qualifier: {entity: 'person', id: '*'}
-      await Beans.get(ManifestService).unregisterIntentions({type: 'view', qualifier: {entity: 'person', id: '*'}});
+      // Remove intentions using following qualifier: {entity: 'person', mode: '*'}
+      await Beans.get(ManifestService).unregisterIntentions({type: 'view', qualifier: {entity: 'person', mode: '*'}});
 
       // Expect removal and lookup to be symmetrical, i.e., a subsequent lookup with the same qualifier as used for the removal should return nothing
       // Expect removal and lookup to be symmetrical, i.e., a subsequent lookup with the same qualifier as used for the removal should return nothing
-      Beans.get(ManifestService).lookupIntentions$({type: 'view', qualifier: {entity: 'person', id: '*'}}).subscribe(captor.reset());
+      Beans.get(ManifestService).lookupIntentions$({type: 'view', qualifier: {entity: 'person', mode: '*'}}).subscribe(captor.reset());
       await expectEmissions(captor).toEqual([[]]);
 
       // Expect intentions
       Beans.get(ManifestService).lookupIntentions$({type: 'view'}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[qualifier1Intention, qualifier2Intention, qualifier3Intention, qualifier4Intention, qualifier5Intention, qualifier6Intention, qualifier7Intention, qualifier8Intention, qualifier9Intention, qualifier10Intention]]);
-    });
-
-    it('should interpret the question mark (?) as value and not as wildcard when removing intentions', async () => {
-      await MicrofrontendPlatform.startHost({
-        host: {symbolicName: 'host-app', intentionRegisterApiDisabled: false},
-        applications: [],
-      });
-
-      // Register intentions
-      const asteriskQualifierIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '*'}}, 'host-app');
-      const optionalQualifierIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '?'}}, 'host-app');
-      const exactQualifierIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: 'exact'}}, 'host-app');
-
-      const qualifier1Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person'}}, 'host-app');
-      const qualifier2Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '*', other: 'property'}}, 'host-app');
-      const qualifier3Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '?', other: 'property'}}, 'host-app');
-      const qualifier4Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: 'exact', other: 'property'}}, 'host-app');
-      const qualifier5Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
-      const qualifier6Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {}}, 'host-app');
-      const qualifier7Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: null}, 'host-app');
-      const qualifier8Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: undefined}, 'host-app');
-      const qualifier9Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view'}, 'host-app');
-      const qualifier10Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {'*': '*'}}, 'host-app');
-
-      const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
-
-      // PRE-CONDITION: Verify all intentions to be registered
-      Beans.get(ManifestService).lookupIntentions$({type: 'view'}).subscribe(captor);
-      await expectEmissions(captor).toEqual([[asteriskQualifierIntention, optionalQualifierIntention, exactQualifierIntention, qualifier1Intention, qualifier2Intention, qualifier3Intention, qualifier4Intention, qualifier5Intention, qualifier6Intention, qualifier7Intention, qualifier8Intention, qualifier9Intention, qualifier10Intention]]);
-
-      // Remove intentions using following qualifier: {entity: 'person', id: '?'}
-      await Beans.get(ManifestService).unregisterIntentions({type: 'view', qualifier: {entity: 'person', id: '?'}});
-
-      // Expect removal and lookup to be symmetrical, i.e., a subsequent lookup with the same qualifier as used for the removal should return nothing
-      Beans.get(ManifestService).lookupIntentions$({type: 'view', qualifier: {entity: 'person', id: '?'}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[]]);
-
-      // Expect intentions
-      Beans.get(ManifestService).lookupIntentions$({type: 'view'}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[asteriskQualifierIntention, exactQualifierIntention, qualifier1Intention, qualifier2Intention, qualifier3Intention, qualifier4Intention, qualifier5Intention, qualifier6Intention, qualifier7Intention, qualifier8Intention, qualifier9Intention, qualifier10Intention]]);
+      await expectEmissions(captor).toEqual([[qualifier1Intention, qualifier2Intention, qualifier3Intention, qualifier4Intention, qualifier5Intention, qualifier6Intention, qualifier7Intention, qualifier8Intention, qualifier9Intention]]);
     });
 
     it('should allow removing intentions using an exact qualifier together with the any-more wildcard (**) ', async () => {
@@ -1144,37 +872,35 @@ describe('ManifestService', () => {
       });
 
       // Register intentions
-      const asteriskQualifierIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '*'}}, 'host-app');
-      const optionalQualifierIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '?'}}, 'host-app');
-      const exactQualifierIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: 'exact'}}, 'host-app');
+      const asteriskQualifierIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: '*'}}, 'host-app');
+      const exactQualifierIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app');
 
       const qualifier1Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person'}}, 'host-app');
-      const qualifier2Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '*', other: 'property'}}, 'host-app');
-      const qualifier3Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '?', other: 'property'}}, 'host-app');
-      const qualifier4Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: 'exact', other: 'property'}}, 'host-app');
-      const qualifier5Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
-      const qualifier6Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {}}, 'host-app');
-      const qualifier7Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: null}, 'host-app');
-      const qualifier8Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: undefined}, 'host-app');
-      const qualifier9Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view'}, 'host-app');
-      const qualifier10Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {'*': '*'}}, 'host-app');
+      const qualifier2Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: '*', other: 'property'}}, 'host-app');
+      const qualifier3Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app');
+      const qualifier4Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
+      const qualifier5Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {}}, 'host-app');
+      const qualifier6Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: null}, 'host-app');
+      const qualifier7Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: undefined}, 'host-app');
+      const qualifier8Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view'}, 'host-app');
+      const qualifier9Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {'*': '*'}}, 'host-app');
 
       const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
 
       // PRE-CONDITION: Verify all intentions to be registered
       Beans.get(ManifestService).lookupIntentions$({type: 'view'}).subscribe(captor);
-      await expectEmissions(captor).toEqual([[asteriskQualifierIntention, optionalQualifierIntention, exactQualifierIntention, qualifier1Intention, qualifier2Intention, qualifier3Intention, qualifier4Intention, qualifier5Intention, qualifier6Intention, qualifier7Intention, qualifier8Intention, qualifier9Intention, qualifier10Intention]]);
+      await expectEmissions(captor).toEqual([[asteriskQualifierIntention, exactQualifierIntention, qualifier1Intention, qualifier2Intention, qualifier3Intention, qualifier4Intention, qualifier5Intention, qualifier6Intention, qualifier7Intention, qualifier8Intention, qualifier9Intention]]);
 
-      // Remove intentions using following qualifier: {entity: 'person', id: 'exact', '*': '*'}
-      await Beans.get(ManifestService).unregisterIntentions({type: 'view', qualifier: {'entity': 'person', 'id': 'exact', '*': '*'}});
+      // Remove intentions using following qualifier: {entity: 'person', mode: 'new', '*': '*'}
+      await Beans.get(ManifestService).unregisterIntentions({type: 'view', qualifier: {entity: 'person', mode: 'new', '*': '*'}});
 
       // Expect removal and lookup to be symmetrical, i.e., a subsequent lookup with the same qualifier as used for the removal should return nothing
-      Beans.get(ManifestService).lookupIntentions$({type: 'view', qualifier: {'entity': 'person', 'id': 'exact', '*': '*'}}).subscribe(captor.reset());
+      Beans.get(ManifestService).lookupIntentions$({type: 'view', qualifier: {entity: 'person', mode: 'new', '*': '*'}}).subscribe(captor.reset());
       await expectEmissions(captor).toEqual([[]]);
 
       // Expect intentions
       Beans.get(ManifestService).lookupIntentions$({type: 'view'}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[asteriskQualifierIntention, optionalQualifierIntention, qualifier1Intention, qualifier2Intention, qualifier3Intention, qualifier5Intention, qualifier6Intention, qualifier7Intention, qualifier8Intention, qualifier9Intention, qualifier10Intention]]);
+      await expectEmissions(captor).toEqual([[asteriskQualifierIntention, qualifier1Intention, qualifier2Intention, qualifier4Intention, qualifier5Intention, qualifier6Intention, qualifier7Intention, qualifier8Intention, qualifier9Intention]]);
     });
 
     it('should allow removing intentions using the asterisk wildcard (*) together with the any-more wildcard (**) ', async () => {
@@ -1184,77 +910,35 @@ describe('ManifestService', () => {
       });
 
       // Register intentions
-      const asteriskQualifierIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '*'}}, 'host-app');
-      const optionalQualifierIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '?'}}, 'host-app');
-      const exactQualifierIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: 'exact'}}, 'host-app');
+      const asteriskQualifierIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: '*'}}, 'host-app');
+      const exactQualifierIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app');
 
       const qualifier1Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person'}}, 'host-app');
-      const qualifier2Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '*', other: 'property'}}, 'host-app');
-      const qualifier3Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '?', other: 'property'}}, 'host-app');
-      const qualifier4Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: 'exact', other: 'property'}}, 'host-app');
-      const qualifier5Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
-      const qualifier6Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {}}, 'host-app');
-      const qualifier7Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: null}, 'host-app');
-      const qualifier8Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: undefined}, 'host-app');
-      const qualifier9Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view'}, 'host-app');
-      const qualifier10Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {'*': '*'}}, 'host-app');
+      const qualifier2Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: '*', other: 'property'}}, 'host-app');
+      const qualifier3Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app');
+      const qualifier4Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
+      const qualifier5Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {}}, 'host-app');
+      const qualifier6Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: null}, 'host-app');
+      const qualifier7Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: undefined}, 'host-app');
+      const qualifier8Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view'}, 'host-app');
+      const qualifier9Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {'*': '*'}}, 'host-app');
 
       const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
 
       // PRE-CONDITION: Verify all intentions to be registered
       Beans.get(ManifestService).lookupIntentions$({type: 'view'}).subscribe(captor);
-      await expectEmissions(captor).toEqual([[asteriskQualifierIntention, optionalQualifierIntention, exactQualifierIntention, qualifier1Intention, qualifier2Intention, qualifier3Intention, qualifier4Intention, qualifier5Intention, qualifier6Intention, qualifier7Intention, qualifier8Intention, qualifier9Intention, qualifier10Intention]]);
+      await expectEmissions(captor).toEqual([[asteriskQualifierIntention, exactQualifierIntention, qualifier1Intention, qualifier2Intention, qualifier3Intention, qualifier4Intention, qualifier5Intention, qualifier6Intention, qualifier7Intention, qualifier8Intention, qualifier9Intention]]);
 
-      // Remove intentions using following qualifier: {entity: 'person', id: '*', '*': '*'}
-      await Beans.get(ManifestService).unregisterIntentions({type: 'view', qualifier: {'entity': 'person', 'id': '*', '*': '*'}});
+      // Remove intentions using following qualifier: {entity: 'person', mode: '*', '*': '*'}
+      await Beans.get(ManifestService).unregisterIntentions({type: 'view', qualifier: {entity: 'person', mode: '*', '*': '*'}});
 
       // Expect removal and lookup to be symmetrical, i.e., a subsequent lookup with the same qualifier as used for the removal should return nothing
-      Beans.get(ManifestService).lookupIntentions$({type: 'view', qualifier: {'entity': 'person', 'id': '*', '*': '*'}}).subscribe(captor.reset());
+      Beans.get(ManifestService).lookupIntentions$({type: 'view', qualifier: {entity: 'person', mode: '*', '*': '*'}}).subscribe(captor.reset());
       await expectEmissions(captor).toEqual([[]]);
 
       // Expect intentions
       Beans.get(ManifestService).lookupIntentions$({type: 'view'}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[qualifier1Intention, qualifier5Intention, qualifier6Intention, qualifier7Intention, qualifier8Intention, qualifier9Intention, qualifier10Intention]]);
-    });
-
-    it('should interpret the question mark (?) as value (and not as wildcard) when removing intentions using the any-more wildcard (**)', async () => {
-      await MicrofrontendPlatform.startHost({
-        host: {symbolicName: 'host-app', intentionRegisterApiDisabled: false},
-        applications: [],
-      });
-
-      // Register intentions
-      const asteriskQualifierIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '*'}}, 'host-app');
-      const optionalQualifierIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '?'}}, 'host-app');
-      const exactQualifierIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: 'exact'}}, 'host-app');
-
-      const qualifier1Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person'}}, 'host-app');
-      const qualifier2Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '*', other: 'property'}}, 'host-app');
-      const qualifier3Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '?', other: 'property'}}, 'host-app');
-      const qualifier4Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: 'exact', other: 'property'}}, 'host-app');
-      const qualifier5Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
-      const qualifier6Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {}}, 'host-app');
-      const qualifier7Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: null}, 'host-app');
-      const qualifier8Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: undefined}, 'host-app');
-      const qualifier9Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view'}, 'host-app');
-      const qualifier10Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {'*': '*'}}, 'host-app');
-
-      const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
-
-      // PRE-CONDITION: Verify all intentions to be registered
-      Beans.get(ManifestService).lookupIntentions$({type: 'view'}).subscribe(captor);
-      await expectEmissions(captor).toEqual([[asteriskQualifierIntention, optionalQualifierIntention, exactQualifierIntention, qualifier1Intention, qualifier2Intention, qualifier3Intention, qualifier4Intention, qualifier5Intention, qualifier6Intention, qualifier7Intention, qualifier8Intention, qualifier9Intention, qualifier10Intention]]);
-
-      // Remove intentions using following qualifier: {entity: 'person', id: '?', '*': '*'}
-      await Beans.get(ManifestService).unregisterIntentions({type: 'view', qualifier: {'entity': 'person', 'id': '?', '*': '*'}});
-
-      // Expect removal and lookup to be symmetrical, i.e., a subsequent lookup with the same qualifier as used for the removal should return nothing
-      Beans.get(ManifestService).lookupIntentions$({type: 'view', qualifier: {'entity': 'person', 'id': '?', '*': '*'}}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[]]);
-
-      // Expect intentions
-      Beans.get(ManifestService).lookupIntentions$({type: 'view'}).subscribe(captor.reset());
-      await expectEmissions(captor).toEqual([[asteriskQualifierIntention, exactQualifierIntention, qualifier1Intention, qualifier2Intention, qualifier4Intention, qualifier5Intention, qualifier6Intention, qualifier7Intention, qualifier8Intention, qualifier9Intention, qualifier10Intention]]);
+      await expectEmissions(captor).toEqual([[qualifier1Intention, qualifier4Intention, qualifier5Intention, qualifier6Intention, qualifier7Intention, qualifier8Intention, qualifier9Intention]]);
     });
 
     it('should allow removing all intentions using the any-more wildcard (**)', async () => {
@@ -1264,26 +948,24 @@ describe('ManifestService', () => {
       });
 
       // Register intentions
-      const asteriskQualifierIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '*'}}, 'host-app');
-      const optionalQualifierIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '?'}}, 'host-app');
-      const exactQualifierIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: 'exact'}}, 'host-app');
+      const asteriskQualifierIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: '*'}}, 'host-app');
+      const exactQualifierIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app');
 
       const qualifier1Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person'}}, 'host-app');
-      const qualifier2Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '*', other: 'property'}}, 'host-app');
-      const qualifier3Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '?', other: 'property'}}, 'host-app');
-      const qualifier4Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: 'exact', other: 'property'}}, 'host-app');
-      const qualifier5Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
-      const qualifier6Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {}}, 'host-app');
-      const qualifier7Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: null}, 'host-app');
-      const qualifier8Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: undefined}, 'host-app');
-      const qualifier9Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view'}, 'host-app');
-      const qualifier10Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {'*': '*'}}, 'host-app');
+      const qualifier2Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: '*', other: 'property'}}, 'host-app');
+      const qualifier3Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app');
+      const qualifier4Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
+      const qualifier5Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {}}, 'host-app');
+      const qualifier6Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: null}, 'host-app');
+      const qualifier7Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: undefined}, 'host-app');
+      const qualifier8Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view'}, 'host-app');
+      const qualifier9Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {'*': '*'}}, 'host-app');
 
       const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
 
       // PRE-CONDITION: Verify all intentions to be registered
       Beans.get(ManifestService).lookupIntentions$({type: 'view'}).subscribe(captor);
-      await expectEmissions(captor).toEqual([[asteriskQualifierIntention, optionalQualifierIntention, exactQualifierIntention, qualifier1Intention, qualifier2Intention, qualifier3Intention, qualifier4Intention, qualifier5Intention, qualifier6Intention, qualifier7Intention, qualifier8Intention, qualifier9Intention, qualifier10Intention]]);
+      await expectEmissions(captor).toEqual([[asteriskQualifierIntention, exactQualifierIntention, qualifier1Intention, qualifier2Intention, qualifier3Intention, qualifier4Intention, qualifier5Intention, qualifier6Intention, qualifier7Intention, qualifier8Intention, qualifier9Intention]]);
 
       // Remove intentions using following qualifier: {'*': '*'}
       await Beans.get(ManifestService).unregisterIntentions({type: 'view', qualifier: {'*': '*'}});
@@ -1300,26 +982,24 @@ describe('ManifestService', () => {
       });
 
       // Register intentions
-      const asteriskQualifierIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '*'}}, 'host-app');
-      const optionalQualifierIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '?'}}, 'host-app');
-      const exactQualifierIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: 'exact'}}, 'host-app');
+      const asteriskQualifierIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: '*'}}, 'host-app');
+      const exactQualifierIntention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app');
 
       const qualifier1Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person'}}, 'host-app');
-      const qualifier2Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '*', other: 'property'}}, 'host-app');
-      const qualifier3Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '?', other: 'property'}}, 'host-app');
-      const qualifier4Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: 'exact', other: 'property'}}, 'host-app');
-      const qualifier5Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
-      const qualifier6Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {}}, 'host-app');
-      const qualifier7Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: null}, 'host-app');
-      const qualifier8Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: undefined}, 'host-app');
-      const qualifier9Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view'}, 'host-app');
-      const qualifier10Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {'*': '*'}}, 'host-app');
+      const qualifier2Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: '*', other: 'property'}}, 'host-app');
+      const qualifier3Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app');
+      const qualifier4Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
+      const qualifier5Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {}}, 'host-app');
+      const qualifier6Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: null}, 'host-app');
+      const qualifier7Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: undefined}, 'host-app');
+      const qualifier8Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view'}, 'host-app');
+      const qualifier9Intention = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {'*': '*'}}, 'host-app');
 
       const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
 
       // PRE-CONDITION: Verify all intentions to be registered
       Beans.get(ManifestService).lookupIntentions$({type: 'view'}).subscribe(captor);
-      await expectEmissions(captor).toEqual([[asteriskQualifierIntention, optionalQualifierIntention, exactQualifierIntention, qualifier1Intention, qualifier2Intention, qualifier3Intention, qualifier4Intention, qualifier5Intention, qualifier6Intention, qualifier7Intention, qualifier8Intention, qualifier9Intention, qualifier10Intention]]);
+      await expectEmissions(captor).toEqual([[asteriskQualifierIntention, exactQualifierIntention, qualifier1Intention, qualifier2Intention, qualifier3Intention, qualifier4Intention, qualifier5Intention, qualifier6Intention, qualifier7Intention, qualifier8Intention, qualifier9Intention]]);
 
       // Remove intentions using no qualifier
       await Beans.get(ManifestService).unregisterIntentions({type: 'view'});
@@ -1335,8 +1015,8 @@ describe('ManifestService', () => {
         applications: [{symbolicName: 'app-1', manifestUrl: new ManifestFixture({name: 'App 1'}).serve()}],
       });
 
-      const intentionIdHostApp = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '*'}}, 'host-app');
-      const intentionIdApp1 = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '*'}}, 'app-1');
+      const intentionIdHostApp = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: '*'}}, 'host-app');
+      const intentionIdApp1 = Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: '*'}}, 'app-1');
 
       // Unregister all intentions of the host app.
       await Beans.get(ManifestService).unregisterIntentions();

--- a/projects/scion/microfrontend-platform/src/lib/client/manifest-registry/manifest-service.ts
+++ b/projects/scion/microfrontend-platform/src/lib/client/manifest-registry/manifest-service.ts
@@ -148,7 +148,7 @@ export class ManifestService implements Initializer {
   /**
    * Registers the given intention, allowing the application to interact with public capabilities matching the intention.
    *
-   * The intention can match multiple capabilities by using wildcards (such as `*` or `?`) in the qualifier.
+   * The intention can match multiple capabilities by using the asterisk wildcard in the qualifier.
    *
    * <strong>This operation requires that the 'Intention Registration API' is enabled for your application.</strong>
    *

--- a/projects/scion/microfrontend-platform/src/lib/client/messaging/intent-client.ts
+++ b/projects/scion/microfrontend-platform/src/lib/client/messaging/intent-client.ts
@@ -128,21 +128,12 @@ export abstract class IntentClient {
    *  });
    * ```
    *
-   * @param  selector - Allows filtering intents. The qualifier allows using wildcards (such as `*` or `?`) to match multiple intents simultaneously.\
-   *         Note that the passed filter is only a filter for intents the application is qualified for, i.e., provides a fulfilling capability visible
-   *         to the sender.
-   *         <p>
-   *         <ul>
-   *           <li>**Asterisk wildcard character (`*`):**\
-   *             <ul>
-   *               <li>If used as qualifier property key, matches intents even if having additional properties. Use it like this: `{'*': '*'}`.</li>
-   *               <li>If used as qualifier property value, requires intents to contain that property, but with any value allowed (except for `null` or `undefined` values).</li>
-   *             </ul>
-   *           </li>
-   *           <li>**Optional wildcard character (`?`):**\
-   *               Is allowed as qualifier property value only and matches intents regardless of having or not having that property.
-   *           </li>
-   *         </ul>
+   * @param  selector - Allows filtering intents. Note that the passed filter is only a filter for intents the application is qualified for, i.e., provides a fulfilling capability visible to the sender.
+   *         In the qualifier of the filter, you can use the asterisk wildcard character (`*`) to match multiple intents simultaneously.
+   *         - Asterisk wildcard character (*)
+   *           Matches intents with such a qualifier property no matter of its value (except `null` or `undefined`). Use it like this: `{property: '*'}`.
+   *         - Partial wildcard (**)
+   *           Matches intents even if having additional properties. Use it like this: `{'*': '*'}`.
    *
    * @return An Observable that emits received intents. It never completes.
    */
@@ -185,8 +176,11 @@ export interface IntentSelector {
    */
   type?: string;
   /**
-   * If specified, filters intents matching the given qualifier. You can use the asterisk wildcard (`*`)
-   * or optional wildcard character (`?`) to match multiple intents.
+   * If specified, filters intents matching the given qualifier. You can use the asterisk wildcard (`*`) to match multiple intents.
+   * - Asterisk wildcard character (*)
+   *   Matches intents with such a qualifier property no matter of its value (except `null` or `undefined`). Use it like this: `{property: '*'}`.
+   * - Partial wildcard (**)
+   *   Matches intents even if having additional properties. Use it like this: `{'*': '*'}`.
    */
   qualifier?: Qualifier;
 }

--- a/projects/scion/microfrontend-platform/src/lib/client/messaging/messaging.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/client/messaging/messaging.spec.ts
@@ -946,57 +946,21 @@ describe('Messaging', () => {
     await expectEmissions(intentCaptor).toEqual(['intent 1', 'intent 2']);
   });
 
-  it('should receive an intent for a capability having an exact qualifier', async () => {
+  it(`should receive an intent for a capability having the qualifier {entity: 'person', mode: 'new'}`, async () => {
     await MicrofrontendPlatform.startHost({applications: []});
 
     // Register capability
-    const capabilityId = await Beans.get(ManifestService).registerCapability({type: 'view', qualifier: {entity: 'person', id: '5'}});
+    const capabilityId = await Beans.get(ManifestService).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}});
 
     // Subscribe for intents
     const intentCaptor = new ObserveCaptor(capabilityIdExtractFn);
     Beans.get(IntentClient).observe$<string>().subscribe(intentCaptor);
 
     // Publish the intent
-    await Beans.get(IntentClient).publish({type: 'view', qualifier: {entity: 'person', id: '5'}});
+    await Beans.get(IntentClient).publish({type: 'view', qualifier: {entity: 'person', mode: 'new'}});
 
     // Expect the intent to be received
     await expectEmissions(intentCaptor).toEqual([capabilityId]);
-  });
-
-  it('should receive an intent for a capability having an asterisk qualifier', async () => {
-    await MicrofrontendPlatform.startHost({applications: []});
-
-    // Register capability
-    const capabilityId = await Beans.get(ManifestService).registerCapability({type: 'view', qualifier: {entity: 'person', id: '*'}});
-
-    // Subscribe for intents
-    const intentCaptor = new ObserveCaptor(capabilityIdExtractFn);
-    Beans.get(IntentClient).observe$<string>().subscribe(intentCaptor);
-
-    // Publish the intent
-    await Beans.get(IntentClient).publish({type: 'view', qualifier: {entity: 'person', id: '5'}});
-
-    // Expect the intent to be received
-    await expectEmissions(intentCaptor).toEqual([capabilityId]);
-  });
-
-  it('should receive an intent for a capability having an optional qualifier', async () => {
-    await MicrofrontendPlatform.startHost({applications: []});
-
-    // Register capability
-    const capabilityId = await Beans.get(ManifestService).registerCapability({type: 'view', qualifier: {entity: 'person', id: '?'}});
-
-    // Publish and receive intent published to {entity: 'person', id: '5'}
-    const intentCaptor1 = new ObserveCaptor(capabilityIdExtractFn);
-    Beans.get(IntentClient).observe$<string>().subscribe(intentCaptor1);
-    await Beans.get(IntentClient).publish({type: 'view', qualifier: {entity: 'person', id: '5'}});
-    await expectEmissions(intentCaptor1).toEqual([capabilityId]);
-
-    // Publish and receive intent published to {entity: 'person'}
-    const intentCaptor2 = new ObserveCaptor(capabilityIdExtractFn);
-    Beans.get(IntentClient).observe$<string>().subscribe(intentCaptor2);
-    await Beans.get(IntentClient).publish({type: 'view', qualifier: {entity: 'person'}});
-    await expectEmissions(intentCaptor2).toEqual([capabilityId]);
   });
 
   it('should transport topic message to subscribed client(s) only', async () => {
@@ -1195,17 +1159,17 @@ describe('Messaging', () => {
   it('should throw if the qualifier of an intent contains wildcard characters', async () => {
     await MicrofrontendPlatform.startHost({applications: []});
 
-    expect(() => Beans.get(IntentClient).publish({type: 'type', qualifier: {entity: 'person', id: '*'}})).toThrowError(/IllegalQualifierError/);
-    expect(() => Beans.get(IntentClient).publish({type: 'type', qualifier: {entity: 'person', id: '?'}})).toThrowError(/IllegalQualifierError/);
-    expect(() => Beans.get(IntentClient).publish({type: 'type', qualifier: {entity: '*', id: '*'}})).toThrowError(/IllegalQualifierError/);
+    expect(() => Beans.get(IntentClient).publish({type: 'type', qualifier: {entity: 'person', mode: '*'}})).toThrowError(/IllegalQualifierError/);
+    expect(() => Beans.get(IntentClient).publish({type: 'type', qualifier: {entity: 'person', mode: '?'}})).toThrowError(/IllegalQualifierError/);
+    expect(() => Beans.get(IntentClient).publish({type: 'type', qualifier: {entity: '*', mode: '*'}})).toThrowError(/IllegalQualifierError/);
   });
 
   it('should throw if the qualifier of an intent request contains wildcard characters', async () => {
     await MicrofrontendPlatform.startHost({applications: []});
 
-    expect(() => Beans.get(IntentClient).request$({type: 'type', qualifier: {entity: 'person', id: '*'}})).toThrowError(/IllegalQualifierError/);
-    expect(() => Beans.get(IntentClient).request$({type: 'type', qualifier: {entity: 'person', id: '?'}})).toThrowError(/IllegalQualifierError/);
-    expect(() => Beans.get(IntentClient).request$({type: 'type', qualifier: {entity: '*', id: '*'}})).toThrowError(/IllegalQualifierError/);
+    expect(() => Beans.get(IntentClient).request$({type: 'type', qualifier: {entity: 'person', mode: '*'}})).toThrowError(/IllegalQualifierError/);
+    expect(() => Beans.get(IntentClient).request$({type: 'type', qualifier: {entity: 'person', mode: '?'}})).toThrowError(/IllegalQualifierError/);
+    expect(() => Beans.get(IntentClient).request$({type: 'type', qualifier: {entity: '*', mode: '*'}})).toThrowError(/IllegalQualifierError/);
   });
 
   it('should prevent overriding platform specific message headers [pub/sub]', async () => {

--- a/projects/scion/microfrontend-platform/src/lib/host/manifest-registry/manifest-object-store.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/host/manifest-registry/manifest-object-store.spec.ts
@@ -28,7 +28,6 @@ describe('ManifestObjectStore', () => {
       const nullQualifierManifestObject: ManifestObject = {type: 'type1', qualifier: null, metadata: {id: 'id_nullQualifierManifestObject', appSymbolicName: 'app'}};
       const emptyQualifierManifestObject: ManifestObject = {type: 'type1', qualifier: {}, metadata: {id: 'id_emptyQualifierManifestObject', appSymbolicName: 'app'}};
       const asteriskQualifierManifestObject: ManifestObject = {type: 'type2', qualifier: {entity: '*'}, metadata: {id: 'id_asteriskQualifierManifestObject', appSymbolicName: 'app'}};
-      const optionalQualifierManifestObject: ManifestObject = {type: 'type2', qualifier: {entity: '?'}, metadata: {id: 'id_optionalQualifierManifestObject', appSymbolicName: 'app'}};
       const exactQualifierManifestObject: ManifestObject = {type: 'type3', qualifier: {entity: 'test'}, metadata: {id: 'id_exactQualifierManifestObject', appSymbolicName: 'app'}};
       const anyQualifierManifestObject: ManifestObject = {type: 'type3', qualifier: {'*': '*'}, metadata: {id: 'id_anyQualifierManifestObject', appSymbolicName: 'app'}};
 
@@ -36,7 +35,6 @@ describe('ManifestObjectStore', () => {
       store.add(nullQualifierManifestObject);
       store.add(emptyQualifierManifestObject);
       store.add(asteriskQualifierManifestObject);
-      store.add(optionalQualifierManifestObject);
       store.add(exactQualifierManifestObject);
       store.add(anyQualifierManifestObject);
 
@@ -44,7 +42,6 @@ describe('ManifestObjectStore', () => {
       expect(store.find({id: 'id_nullQualifierManifestObject'})).toEqual([nullQualifierManifestObject]);
       expect(store.find({id: 'id_emptyQualifierManifestObject'})).toEqual([emptyQualifierManifestObject]);
       expect(store.find({id: 'id_asteriskQualifierManifestObject'})).toEqual([asteriskQualifierManifestObject]);
-      expect(store.find({id: 'id_optionalQualifierManifestObject'})).toEqual([optionalQualifierManifestObject]);
       expect(store.find({id: 'id_exactQualifierManifestObject'})).toEqual([exactQualifierManifestObject]);
       expect(store.find({id: 'id_anyQualifierManifestObject'})).toEqual([anyQualifierManifestObject]);
     });
@@ -54,7 +51,6 @@ describe('ManifestObjectStore', () => {
       const nullQualifierManifestObject: ManifestObject = {type: 'type1', qualifier: null, metadata: {id: 'id_nullQualifierManifestObject', appSymbolicName: 'app'}};
       const emptyQualifierManifestObject: ManifestObject = {type: 'type1', qualifier: {}, metadata: {id: 'id_emptyQualifierManifestObject', appSymbolicName: 'app'}};
       const asteriskQualifierManifestObject: ManifestObject = {type: 'type2', qualifier: {entity: '*'}, metadata: {id: 'id_asteriskQualifierManifestObject', appSymbolicName: 'app'}};
-      const optionalQualifierManifestObject: ManifestObject = {type: 'type2', qualifier: {entity: '?'}, metadata: {id: 'id_optionalQualifierManifestObject', appSymbolicName: 'app'}};
       const exactQualifierManifestObject: ManifestObject = {type: 'type3', qualifier: {entity: 'test'}, metadata: {id: 'id_exactQualifierManifestObject', appSymbolicName: 'app'}};
       const anyQualifierManifestObject: ManifestObject = {type: 'type3', qualifier: {'*': '*'}, metadata: {id: 'id_anyQualifierManifestObject', appSymbolicName: 'app'}};
 
@@ -62,12 +58,11 @@ describe('ManifestObjectStore', () => {
       store.add(nullQualifierManifestObject);
       store.add(emptyQualifierManifestObject);
       store.add(asteriskQualifierManifestObject);
-      store.add(optionalQualifierManifestObject);
       store.add(exactQualifierManifestObject);
       store.add(anyQualifierManifestObject);
 
       expect(store.find({type: 'type1'})).toEqual([undefinedQualifierManifestObject, nullQualifierManifestObject, emptyQualifierManifestObject]);
-      expect(store.find({type: 'type2'})).toEqual([asteriskQualifierManifestObject, optionalQualifierManifestObject]);
+      expect(store.find({type: 'type2'})).toEqual([asteriskQualifierManifestObject]);
       expect(store.find({type: 'type3'})).toEqual([exactQualifierManifestObject, anyQualifierManifestObject]);
     });
 
@@ -76,7 +71,6 @@ describe('ManifestObjectStore', () => {
       const nullQualifierManifestObject: ManifestObject = {type: 'type1', qualifier: null, metadata: {id: 'id_nullQualifierManifestObject', appSymbolicName: 'app'}};
       const emptyQualifierManifestObject: ManifestObject = {type: 'type1', qualifier: {}, metadata: {id: 'id_emptyQualifierManifestObject', appSymbolicName: 'app'}};
       const asteriskQualifierManifestObject: ManifestObject = {type: 'type2', qualifier: {entity: '*'}, metadata: {id: 'id_asteriskQualifierManifestObject', appSymbolicName: 'app'}};
-      const optionalQualifierManifestObject: ManifestObject = {type: 'type2', qualifier: {entity: '?'}, metadata: {id: 'id_optionalQualifierManifestObject', appSymbolicName: 'app'}};
       const exactQualifierManifestObject: ManifestObject = {type: 'type3', qualifier: {entity: 'test'}, metadata: {id: 'id_exactQualifierManifestObject', appSymbolicName: 'app'}};
       const anyQualifierManifestObject: ManifestObject = {type: 'type3', qualifier: {'*': '*'}, metadata: {id: 'id_anyQualifierManifestObject', appSymbolicName: 'app'}};
 
@@ -84,16 +78,14 @@ describe('ManifestObjectStore', () => {
       store.add(nullQualifierManifestObject);
       store.add(emptyQualifierManifestObject);
       store.add(asteriskQualifierManifestObject);
-      store.add(optionalQualifierManifestObject);
       store.add(exactQualifierManifestObject);
       store.add(anyQualifierManifestObject);
 
-      expect(store.find({qualifier: undefined})).toEqual([undefinedQualifierManifestObject, nullQualifierManifestObject, emptyQualifierManifestObject, asteriskQualifierManifestObject, optionalQualifierManifestObject, exactQualifierManifestObject, anyQualifierManifestObject]);
+      expect(store.find({qualifier: undefined})).toEqual([undefinedQualifierManifestObject, nullQualifierManifestObject, emptyQualifierManifestObject, asteriskQualifierManifestObject, exactQualifierManifestObject, anyQualifierManifestObject]);
       expect(store.find({qualifier: null})).toEqual([undefinedQualifierManifestObject, nullQualifierManifestObject, emptyQualifierManifestObject]);
       expect(store.find({qualifier: {}})).toEqual([undefinedQualifierManifestObject, nullQualifierManifestObject, emptyQualifierManifestObject]);
-      expect(store.find({qualifier: {'*': '*'}})).toEqual([undefinedQualifierManifestObject, nullQualifierManifestObject, emptyQualifierManifestObject, asteriskQualifierManifestObject, optionalQualifierManifestObject, exactQualifierManifestObject, anyQualifierManifestObject]);
-      expect(store.find({qualifier: {entity: '*'}})).toEqual([asteriskQualifierManifestObject, optionalQualifierManifestObject, exactQualifierManifestObject]);
-      expect(store.find({qualifier: {entity: '?'}})).toEqual([optionalQualifierManifestObject]);
+      expect(store.find({qualifier: {'*': '*'}})).toEqual([undefinedQualifierManifestObject, nullQualifierManifestObject, emptyQualifierManifestObject, asteriskQualifierManifestObject, exactQualifierManifestObject, anyQualifierManifestObject]);
+      expect(store.find({qualifier: {entity: '*'}})).toEqual([asteriskQualifierManifestObject, exactQualifierManifestObject]);
       expect(store.find({qualifier: {entity: 'test'}})).toEqual([exactQualifierManifestObject]);
     });
 
@@ -102,7 +94,6 @@ describe('ManifestObjectStore', () => {
       const nullQualifierManifestObject: ManifestObject = {type: 'type1', qualifier: null, metadata: {id: 'id_nullQualifierManifestObject', appSymbolicName: 'app1'}};
       const emptyQualifierManifestObject: ManifestObject = {type: 'type1', qualifier: {}, metadata: {id: 'id_emptyQualifierManifestObject', appSymbolicName: 'app2'}};
       const asteriskQualifierManifestObject: ManifestObject = {type: 'type2', qualifier: {entity: '*'}, metadata: {id: 'id_asteriskQualifierManifestObject', appSymbolicName: 'app2'}};
-      const optionalQualifierManifestObject: ManifestObject = {type: 'type2', qualifier: {entity: '?'}, metadata: {id: 'id_optionalQualifierManifestObject', appSymbolicName: 'app3'}};
       const exactQualifierManifestObject: ManifestObject = {type: 'type3', qualifier: {entity: 'test'}, metadata: {id: 'id_exactQualifierManifestObject', appSymbolicName: 'app3'}};
       const anyQualifierManifestObject: ManifestObject = {type: 'type3', qualifier: {'*': '*'}, metadata: {id: 'id_anyQualifierManifestObject', appSymbolicName: 'app3'}};
 
@@ -110,13 +101,12 @@ describe('ManifestObjectStore', () => {
       store.add(nullQualifierManifestObject);
       store.add(emptyQualifierManifestObject);
       store.add(asteriskQualifierManifestObject);
-      store.add(optionalQualifierManifestObject);
       store.add(exactQualifierManifestObject);
       store.add(anyQualifierManifestObject);
 
       expect(store.find({appSymbolicName: 'app1'})).toEqual([undefinedQualifierManifestObject, nullQualifierManifestObject]);
       expect(store.find({appSymbolicName: 'app2'})).toEqual([emptyQualifierManifestObject, asteriskQualifierManifestObject]);
-      expect(store.find({appSymbolicName: 'app3'})).toEqual([optionalQualifierManifestObject, exactQualifierManifestObject, anyQualifierManifestObject]);
+      expect(store.find({appSymbolicName: 'app3'})).toEqual([exactQualifierManifestObject, anyQualifierManifestObject]);
     });
 
     it('should find manifest objects by id and other filter criteria', () => {
@@ -124,7 +114,6 @@ describe('ManifestObjectStore', () => {
       const nullQualifierManifestObject: ManifestObject = {type: 'type1', qualifier: null, metadata: {id: 'id_nullQualifierManifestObject', appSymbolicName: 'app1'}};
       const emptyQualifierManifestObject: ManifestObject = {type: 'type1', qualifier: {}, metadata: {id: 'id_emptyQualifierManifestObject', appSymbolicName: 'app2'}};
       const asteriskQualifierManifestObject: ManifestObject = {type: 'type2', qualifier: {entity: '*'}, metadata: {id: 'id_asteriskQualifierManifestObject', appSymbolicName: 'app2'}};
-      const optionalQualifierManifestObject: ManifestObject = {type: 'type2', qualifier: {entity: '?'}, metadata: {id: 'id_optionalQualifierManifestObject', appSymbolicName: 'app3'}};
       const exactQualifierManifestObject: ManifestObject = {type: 'type3', qualifier: {entity: 'test'}, metadata: {id: 'id_exactQualifierManifestObject', appSymbolicName: 'app3'}};
       const anyQualifierManifestObject: ManifestObject = {type: 'type3', qualifier: {'*': '*'}, metadata: {id: 'id_anyQualifierManifestObject', appSymbolicName: 'app'}};
 
@@ -132,7 +121,6 @@ describe('ManifestObjectStore', () => {
       store.add(nullQualifierManifestObject);
       store.add(emptyQualifierManifestObject);
       store.add(asteriskQualifierManifestObject);
-      store.add(optionalQualifierManifestObject);
       store.add(exactQualifierManifestObject);
       store.add(anyQualifierManifestObject);
 
@@ -152,7 +140,6 @@ describe('ManifestObjectStore', () => {
       const nullQualifierManifestObject: ManifestObject = {type: 'type1', qualifier: null, metadata: {id: 'id_nullQualifierManifestObject', appSymbolicName: 'app1'}};
       const emptyQualifierManifestObject: ManifestObject = {type: 'type1', qualifier: {}, metadata: {id: 'id_emptyQualifierManifestObject', appSymbolicName: 'app2'}};
       const asteriskQualifierManifestObject: ManifestObject = {type: 'type2', qualifier: {entity: '*'}, metadata: {id: 'id_asteriskQualifierManifestObject', appSymbolicName: 'app2'}};
-      const optionalQualifierManifestObject: ManifestObject = {type: 'type2', qualifier: {entity: '?'}, metadata: {id: 'id_optionalQualifierManifestObject', appSymbolicName: 'app3'}};
       const exactQualifierManifestObject: ManifestObject = {type: 'type3', qualifier: {entity: 'test'}, metadata: {id: 'id_exactQualifierManifestObject', appSymbolicName: 'app3'}};
       const anyQualifierManifestObject: ManifestObject = {type: 'type3', qualifier: {'*': '*'}, metadata: {id: 'id_anyQualifierManifestObject', appSymbolicName: 'app3'}};
 
@@ -160,7 +147,6 @@ describe('ManifestObjectStore', () => {
       store.add(nullQualifierManifestObject);
       store.add(emptyQualifierManifestObject);
       store.add(asteriskQualifierManifestObject);
-      store.add(optionalQualifierManifestObject);
       store.add(exactQualifierManifestObject);
       store.add(anyQualifierManifestObject);
 
@@ -174,12 +160,12 @@ describe('ManifestObjectStore', () => {
       expect(store.find({type: 'type1', qualifier: {entity: '*'}})).toEqual([]);
       expect(store.find({type: 'type2', appSymbolicName: 'app1'})).toEqual([]);
       expect(store.find({type: 'type2', appSymbolicName: 'app2'})).toEqual([asteriskQualifierManifestObject]);
-      expect(store.find({type: 'type2', appSymbolicName: 'app3'})).toEqual([optionalQualifierManifestObject]);
-      expect(store.find({type: 'type2', qualifier: undefined})).toEqual([asteriskQualifierManifestObject, optionalQualifierManifestObject]);
+      expect(store.find({type: 'type2', appSymbolicName: 'app3'})).toEqual([]);
+      expect(store.find({type: 'type2', qualifier: undefined})).toEqual([asteriskQualifierManifestObject]);
       expect(store.find({type: 'type2', qualifier: null})).toEqual([]);
       expect(store.find({type: 'type2', qualifier: {}})).toEqual([]);
-      expect(store.find({type: 'type2', qualifier: {'*': '*'}})).toEqual([asteriskQualifierManifestObject, optionalQualifierManifestObject]);
-      expect(store.find({type: 'type2', qualifier: {entity: '*'}})).toEqual([asteriskQualifierManifestObject, optionalQualifierManifestObject]);
+      expect(store.find({type: 'type2', qualifier: {'*': '*'}})).toEqual([asteriskQualifierManifestObject]);
+      expect(store.find({type: 'type2', qualifier: {entity: '*'}})).toEqual([asteriskQualifierManifestObject]);
       expect(store.find({type: 'type3', appSymbolicName: 'app1'})).toEqual([]);
       expect(store.find({type: 'type3', appSymbolicName: 'app2'})).toEqual([]);
       expect(store.find({type: 'type3', appSymbolicName: 'app3'})).toEqual([exactQualifierManifestObject, anyQualifierManifestObject]);
@@ -195,7 +181,6 @@ describe('ManifestObjectStore', () => {
       const nullQualifierManifestObject: ManifestObject = {type: 'type1', qualifier: null, metadata: {id: 'id_nullQualifierManifestObject', appSymbolicName: 'app1'}};
       const emptyQualifierManifestObject: ManifestObject = {type: 'type1', qualifier: {}, metadata: {id: 'id_emptyQualifierManifestObject', appSymbolicName: 'app2'}};
       const asteriskQualifierManifestObject: ManifestObject = {type: 'type2', qualifier: {entity: '*'}, metadata: {id: 'id_asteriskQualifierManifestObject', appSymbolicName: 'app2'}};
-      const optionalQualifierManifestObject: ManifestObject = {type: 'type2', qualifier: {entity: '?'}, metadata: {id: 'id_optionalQualifierManifestObject', appSymbolicName: 'app3'}};
       const exactQualifierManifestObject: ManifestObject = {type: 'type3', qualifier: {entity: 'test'}, metadata: {id: 'id_exactQualifierManifestObject', appSymbolicName: 'app3'}};
       const anyQualifierManifestObject: ManifestObject = {type: 'type3', qualifier: {'*': '*'}, metadata: {id: 'id_anyQualifierManifestObject', appSymbolicName: 'app3'}};
 
@@ -203,7 +188,6 @@ describe('ManifestObjectStore', () => {
       store.add(nullQualifierManifestObject);
       store.add(emptyQualifierManifestObject);
       store.add(asteriskQualifierManifestObject);
-      store.add(optionalQualifierManifestObject);
       store.add(exactQualifierManifestObject);
       store.add(anyQualifierManifestObject);
 
@@ -217,11 +201,11 @@ describe('ManifestObjectStore', () => {
       expect(store.find({appSymbolicName: 'app2', qualifier: {}})).toEqual([emptyQualifierManifestObject]);
       expect(store.find({appSymbolicName: 'app2', qualifier: {'*': '*'}})).toEqual([emptyQualifierManifestObject, asteriskQualifierManifestObject]);
       expect(store.find({appSymbolicName: 'app2', qualifier: {entity: '*'}})).toEqual([asteriskQualifierManifestObject]);
-      expect(store.find({appSymbolicName: 'app3', qualifier: undefined})).toEqual([optionalQualifierManifestObject, exactQualifierManifestObject, anyQualifierManifestObject]);
+      expect(store.find({appSymbolicName: 'app3', qualifier: undefined})).toEqual([exactQualifierManifestObject, anyQualifierManifestObject]);
       expect(store.find({appSymbolicName: 'app3', qualifier: null})).toEqual([]);
       expect(store.find({appSymbolicName: 'app3', qualifier: {}})).toEqual([]);
-      expect(store.find({appSymbolicName: 'app3', qualifier: {'*': '*'}})).toEqual([optionalQualifierManifestObject, exactQualifierManifestObject, anyQualifierManifestObject]);
-      expect(store.find({appSymbolicName: 'app3', qualifier: {entity: '*'}})).toEqual([optionalQualifierManifestObject, exactQualifierManifestObject]);
+      expect(store.find({appSymbolicName: 'app3', qualifier: {'*': '*'}})).toEqual([exactQualifierManifestObject, anyQualifierManifestObject]);
+      expect(store.find({appSymbolicName: 'app3', qualifier: {entity: '*'}})).toEqual([exactQualifierManifestObject]);
     });
   });
 
@@ -239,7 +223,6 @@ describe('ManifestObjectStore', () => {
       const nullQualifierManifestObject: ManifestObject = {type: 'type1', qualifier: null, metadata: {id: 'id_nullQualifierManifestObject', appSymbolicName: 'app'}};
       const emptyQualifierManifestObject: ManifestObject = {type: 'type1', qualifier: {}, metadata: {id: 'id_emptyQualifierManifestObject', appSymbolicName: 'app'}};
       const asteriskQualifierManifestObject: ManifestObject = {type: 'type2', qualifier: {entity: '*'}, metadata: {id: 'id_asteriskQualifierManifestObject', appSymbolicName: 'app'}};
-      const optionalQualifierManifestObject: ManifestObject = {type: 'type2', qualifier: {entity: '?'}, metadata: {id: 'id_optionalQualifierManifestObject', appSymbolicName: 'app'}};
       const exactQualifierManifestObject: ManifestObject = {type: 'type3', qualifier: {entity: 'test'}, metadata: {id: 'id_exactQualifierManifestObject', appSymbolicName: 'app'}};
       const anyQualifierManifestObject: ManifestObject = {type: 'type3', qualifier: {'*': '*'}, metadata: {id: 'id_anyQualifierManifestObject', appSymbolicName: 'app'}};
 
@@ -247,7 +230,6 @@ describe('ManifestObjectStore', () => {
       store.add(nullQualifierManifestObject);
       store.add(emptyQualifierManifestObject);
       store.add(asteriskQualifierManifestObject);
-      store.add(optionalQualifierManifestObject);
       store.add(exactQualifierManifestObject);
       store.add(anyQualifierManifestObject);
 
@@ -255,7 +237,6 @@ describe('ManifestObjectStore', () => {
       store.remove({id: 'id_nullQualifierManifestObject'});
       store.remove({id: 'id_emptyQualifierManifestObject'});
       store.remove({id: 'id_asteriskQualifierManifestObject'});
-      store.remove({id: 'id_optionalQualifierManifestObject'});
       store.remove({id: 'id_exactQualifierManifestObject'});
       store.remove({id: 'id_anyQualifierManifestObject'});
 
@@ -267,7 +248,6 @@ describe('ManifestObjectStore', () => {
       const nullQualifierManifestObject: ManifestObject = {type: 'type1', qualifier: null, metadata: {id: 'id_nullQualifierManifestObject', appSymbolicName: 'app'}};
       const emptyQualifierManifestObject: ManifestObject = {type: 'type1', qualifier: {}, metadata: {id: 'id_emptyQualifierManifestObject', appSymbolicName: 'app'}};
       const asteriskQualifierManifestObject: ManifestObject = {type: 'type2', qualifier: {entity: '*'}, metadata: {id: 'id_asteriskQualifierManifestObject', appSymbolicName: 'app'}};
-      const optionalQualifierManifestObject: ManifestObject = {type: 'type2', qualifier: {entity: '?'}, metadata: {id: 'id_optionalQualifierManifestObject', appSymbolicName: 'app'}};
       const exactQualifierManifestObject: ManifestObject = {type: 'type3', qualifier: {entity: 'test'}, metadata: {id: 'id_exactQualifierManifestObject', appSymbolicName: 'app'}};
       const anyQualifierManifestObject: ManifestObject = {type: 'type3', qualifier: {'*': '*'}, metadata: {id: 'id_anyQualifierManifestObject', appSymbolicName: 'app'}};
 
@@ -275,7 +255,6 @@ describe('ManifestObjectStore', () => {
       store.add(nullQualifierManifestObject);
       store.add(emptyQualifierManifestObject);
       store.add(asteriskQualifierManifestObject);
-      store.add(optionalQualifierManifestObject);
       store.add(exactQualifierManifestObject);
       store.add(anyQualifierManifestObject);
 
@@ -289,7 +268,6 @@ describe('ManifestObjectStore', () => {
       const nullQualifierManifestObject: ManifestObject = {type: 'type1', qualifier: null, metadata: {id: 'id_nullQualifierManifestObject', appSymbolicName: 'app'}};
       const emptyQualifierManifestObject: ManifestObject = {type: 'type1', qualifier: {}, metadata: {id: 'id_emptyQualifierManifestObject', appSymbolicName: 'app'}};
       const asteriskQualifierManifestObject: ManifestObject = {type: 'type2', qualifier: {entity: '*'}, metadata: {id: 'id_asteriskQualifierManifestObject', appSymbolicName: 'app'}};
-      const optionalQualifierManifestObject: ManifestObject = {type: 'type2', qualifier: {entity: '?'}, metadata: {id: 'id_optionalQualifierManifestObject', appSymbolicName: 'app'}};
       const exactQualifierManifestObject: ManifestObject = {type: 'type3', qualifier: {entity: 'test'}, metadata: {id: 'id_exactQualifierManifestObject', appSymbolicName: 'app'}};
       const anyQualifierManifestObject: ManifestObject = {type: 'type3', qualifier: {'*': '*'}, metadata: {id: 'id_anyQualifierManifestObject', appSymbolicName: 'app'}};
 
@@ -297,13 +275,12 @@ describe('ManifestObjectStore', () => {
       store.add(nullQualifierManifestObject);
       store.add(emptyQualifierManifestObject);
       store.add(asteriskQualifierManifestObject);
-      store.add(optionalQualifierManifestObject);
       store.add(exactQualifierManifestObject);
       store.add(anyQualifierManifestObject);
 
       store.remove({qualifier: null});
 
-      expect(store.find({})).toEqual([asteriskQualifierManifestObject, optionalQualifierManifestObject, exactQualifierManifestObject, anyQualifierManifestObject]);
+      expect(store.find({})).toEqual([asteriskQualifierManifestObject, exactQualifierManifestObject, anyQualifierManifestObject]);
     });
 
     it('should remove manifest objects matching the empty qualifier', () => {
@@ -311,7 +288,6 @@ describe('ManifestObjectStore', () => {
       const nullQualifierManifestObject: ManifestObject = {type: 'type1', qualifier: null, metadata: {id: 'id_nullQualifierManifestObject', appSymbolicName: 'app'}};
       const emptyQualifierManifestObject: ManifestObject = {type: 'type1', qualifier: {}, metadata: {id: 'id_emptyQualifierManifestObject', appSymbolicName: 'app'}};
       const asteriskQualifierManifestObject: ManifestObject = {type: 'type2', qualifier: {entity: '*'}, metadata: {id: 'id_asteriskQualifierManifestObject', appSymbolicName: 'app'}};
-      const optionalQualifierManifestObject: ManifestObject = {type: 'type2', qualifier: {entity: '?'}, metadata: {id: 'id_optionalQualifierManifestObject', appSymbolicName: 'app'}};
       const exactQualifierManifestObject: ManifestObject = {type: 'type3', qualifier: {entity: 'test'}, metadata: {id: 'id_exactQualifierManifestObject', appSymbolicName: 'app'}};
       const anyQualifierManifestObject: ManifestObject = {type: 'type3', qualifier: {'*': '*'}, metadata: {id: 'id_anyQualifierManifestObject', appSymbolicName: 'app'}};
 
@@ -319,13 +295,12 @@ describe('ManifestObjectStore', () => {
       store.add(nullQualifierManifestObject);
       store.add(emptyQualifierManifestObject);
       store.add(asteriskQualifierManifestObject);
-      store.add(optionalQualifierManifestObject);
       store.add(exactQualifierManifestObject);
       store.add(anyQualifierManifestObject);
 
       store.remove({qualifier: {}});
 
-      expect(store.find({})).toEqual([asteriskQualifierManifestObject, optionalQualifierManifestObject, exactQualifierManifestObject, anyQualifierManifestObject]);
+      expect(store.find({})).toEqual([asteriskQualifierManifestObject, exactQualifierManifestObject, anyQualifierManifestObject]);
     });
 
     it('should remove manifest objects matching the asterisk wildcard qualifier', () => {
@@ -333,7 +308,6 @@ describe('ManifestObjectStore', () => {
       const nullQualifierManifestObject: ManifestObject = {type: 'type1', qualifier: null, metadata: {id: 'id_nullQualifierManifestObject', appSymbolicName: 'app'}};
       const emptyQualifierManifestObject: ManifestObject = {type: 'type1', qualifier: {}, metadata: {id: 'id_emptyQualifierManifestObject', appSymbolicName: 'app'}};
       const asteriskQualifierManifestObject: ManifestObject = {type: 'type2', qualifier: {entity: '*'}, metadata: {id: 'id_asteriskQualifierManifestObject', appSymbolicName: 'app'}};
-      const optionalQualifierManifestObject: ManifestObject = {type: 'type2', qualifier: {entity: '?'}, metadata: {id: 'id_optionalQualifierManifestObject', appSymbolicName: 'app'}};
       const exactQualifierManifestObject: ManifestObject = {type: 'type3', qualifier: {entity: 'test'}, metadata: {id: 'id_exactQualifierManifestObject', appSymbolicName: 'app'}};
       const anyQualifierManifestObject: ManifestObject = {type: 'type3', qualifier: {'*': '*'}, metadata: {id: 'id_anyQualifierManifestObject', appSymbolicName: 'app'}};
 
@@ -341,7 +315,6 @@ describe('ManifestObjectStore', () => {
       store.add(nullQualifierManifestObject);
       store.add(emptyQualifierManifestObject);
       store.add(asteriskQualifierManifestObject);
-      store.add(optionalQualifierManifestObject);
       store.add(exactQualifierManifestObject);
       store.add(anyQualifierManifestObject);
 
@@ -350,34 +323,11 @@ describe('ManifestObjectStore', () => {
       expect(store.find({})).toEqual([undefinedQualifierManifestObject, nullQualifierManifestObject, emptyQualifierManifestObject, anyQualifierManifestObject]);
     });
 
-    it('should remove manifest objects matching the optional wildcard qualifier', () => {
-      const undefinedQualifierManifestObject: ManifestObject = {type: 'type1', metadata: {id: 'id_undefinedQualifierManifestObject', appSymbolicName: 'app'}};
-      const nullQualifierManifestObject: ManifestObject = {type: 'type1', qualifier: null, metadata: {id: 'id_nullQualifierManifestObject', appSymbolicName: 'app'}};
-      const emptyQualifierManifestObject: ManifestObject = {type: 'type1', qualifier: {}, metadata: {id: 'id_emptyQualifierManifestObject', appSymbolicName: 'app'}};
-      const asteriskQualifierManifestObject: ManifestObject = {type: 'type2', qualifier: {entity: '*'}, metadata: {id: 'id_asteriskQualifierManifestObject', appSymbolicName: 'app'}};
-      const optionalQualifierManifestObject: ManifestObject = {type: 'type2', qualifier: {entity: '?'}, metadata: {id: 'id_optionalQualifierManifestObject', appSymbolicName: 'app'}};
-      const exactQualifierManifestObject: ManifestObject = {type: 'type3', qualifier: {entity: 'test'}, metadata: {id: 'id_exactQualifierManifestObject', appSymbolicName: 'app'}};
-      const anyQualifierManifestObject: ManifestObject = {type: 'type3', qualifier: {'*': '*'}, metadata: {id: 'id_anyQualifierManifestObject', appSymbolicName: 'app'}};
-
-      store.add(undefinedQualifierManifestObject);
-      store.add(nullQualifierManifestObject);
-      store.add(emptyQualifierManifestObject);
-      store.add(asteriskQualifierManifestObject);
-      store.add(optionalQualifierManifestObject);
-      store.add(exactQualifierManifestObject);
-      store.add(anyQualifierManifestObject);
-
-      store.remove({qualifier: {entity: '?'}});
-
-      expect(store.find({})).toEqual([undefinedQualifierManifestObject, nullQualifierManifestObject, emptyQualifierManifestObject, asteriskQualifierManifestObject, exactQualifierManifestObject, anyQualifierManifestObject]);
-    });
-
     it('should remove manifest objects matching the exact qualifier', () => {
       const undefinedQualifierManifestObject: ManifestObject = {type: 'type1', metadata: {id: 'id_undefinedQualifierManifestObject', appSymbolicName: 'app'}};
       const nullQualifierManifestObject: ManifestObject = {type: 'type1', qualifier: null, metadata: {id: 'id_nullQualifierManifestObject', appSymbolicName: 'app'}};
       const emptyQualifierManifestObject: ManifestObject = {type: 'type1', qualifier: {}, metadata: {id: 'id_emptyQualifierManifestObject', appSymbolicName: 'app'}};
       const asteriskQualifierManifestObject: ManifestObject = {type: 'type2', qualifier: {entity: '*'}, metadata: {id: 'id_asteriskQualifierManifestObject', appSymbolicName: 'app'}};
-      const optionalQualifierManifestObject: ManifestObject = {type: 'type2', qualifier: {entity: '?'}, metadata: {id: 'id_optionalQualifierManifestObject', appSymbolicName: 'app'}};
       const exactQualifierManifestObject: ManifestObject = {type: 'type3', qualifier: {entity: 'test'}, metadata: {id: 'id_exactQualifierManifestObject', appSymbolicName: 'app'}};
       const anyQualifierManifestObject: ManifestObject = {type: 'type3', qualifier: {'*': '*'}, metadata: {id: 'id_anyQualifierManifestObject', appSymbolicName: 'app'}};
 
@@ -385,13 +335,12 @@ describe('ManifestObjectStore', () => {
       store.add(nullQualifierManifestObject);
       store.add(emptyQualifierManifestObject);
       store.add(asteriskQualifierManifestObject);
-      store.add(optionalQualifierManifestObject);
       store.add(exactQualifierManifestObject);
       store.add(anyQualifierManifestObject);
 
       store.remove({qualifier: {entity: 'test'}});
 
-      expect(store.find({})).toEqual([undefinedQualifierManifestObject, nullQualifierManifestObject, emptyQualifierManifestObject, asteriskQualifierManifestObject, optionalQualifierManifestObject, anyQualifierManifestObject]);
+      expect(store.find({})).toEqual([undefinedQualifierManifestObject, nullQualifierManifestObject, emptyQualifierManifestObject, asteriskQualifierManifestObject, anyQualifierManifestObject]);
     });
 
     it('should remove manifest objects matching the any-more wildcard (**) qualifier', () => {
@@ -399,7 +348,6 @@ describe('ManifestObjectStore', () => {
       const nullQualifierManifestObject: ManifestObject = {type: 'type1', qualifier: null, metadata: {id: 'id_nullQualifierManifestObject', appSymbolicName: 'app'}};
       const emptyQualifierManifestObject: ManifestObject = {type: 'type1', qualifier: {}, metadata: {id: 'id_emptyQualifierManifestObject', appSymbolicName: 'app'}};
       const asteriskQualifierManifestObject: ManifestObject = {type: 'type2', qualifier: {entity: '*'}, metadata: {id: 'id_asteriskQualifierManifestObject', appSymbolicName: 'app'}};
-      const optionalQualifierManifestObject: ManifestObject = {type: 'type2', qualifier: {entity: '?'}, metadata: {id: 'id_optionalQualifierManifestObject', appSymbolicName: 'app'}};
       const exactQualifierManifestObject: ManifestObject = {type: 'type3', qualifier: {entity: 'test'}, metadata: {id: 'id_exactQualifierManifestObject', appSymbolicName: 'app'}};
       const anyQualifierManifestObject: ManifestObject = {type: 'type3', qualifier: {'*': '*'}, metadata: {id: 'id_anyQualifierManifestObject', appSymbolicName: 'app'}};
 
@@ -407,7 +355,6 @@ describe('ManifestObjectStore', () => {
       store.add(nullQualifierManifestObject);
       store.add(emptyQualifierManifestObject);
       store.add(asteriskQualifierManifestObject);
-      store.add(optionalQualifierManifestObject);
       store.add(exactQualifierManifestObject);
       store.add(anyQualifierManifestObject);
 

--- a/projects/scion/microfrontend-platform/src/lib/host/manifest-registry/manifest-registry.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/host/manifest-registry/manifest-registry.spec.ts
@@ -37,10 +37,10 @@ describe('ManifestRegistry', () => {
         applications: [],
       });
 
-      expect(() => Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', id: '*'}}, 'host-app')).toThrowError(/IllegalQualifierError/);
+      expect(() => Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', mode: '*'}}, 'host-app')).toThrowError(/IllegalQualifierError/);
     });
 
-    it(`should have an implicit intention for a capability having an exact qualifier ({entity: 'person', id: '5'})`, async () => {
+    it(`should have an implicit intention for a capability having the qualifier ({entity: 'person', mode: 'new'})`, async () => {
       await MicrofrontendPlatform.startHost({
         host: {symbolicName: 'host-app'},
         applications: [
@@ -50,67 +50,21 @@ describe('ManifestRegistry', () => {
       });
 
       // Register capability
-      await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '5'}}, 'app-1');
+      await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'app-1');
 
       // Expect app-1 to have an implicit intention because providing the capability
-      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', id: '5'}}, 'app-1')).toBeTrue();
+      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'app-1')).toBeTrue();
 
-      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', id: '999'}}, 'app-1')).toBeFalse();
+      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', mode: 'edit'}}, 'app-1')).toBeFalse();
       expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person'}}, 'app-1')).toBeFalse();
       expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'app-1')).toBeFalse();
-      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', id: '5', other: 'property'}}, 'app-1')).toBeFalse();
+      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'app-1')).toBeFalse();
 
       // Expect app-2 to not have an intention
-      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', id: '5'}}, 'app-2')).toBeFalse();
+      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'app-2')).toBeFalse();
     });
 
-    it(`should have an implicit intention for a capability having an asterisk wildcard qualifier ({entity: 'person', id: '*'})`, async () => {
-      await MicrofrontendPlatform.startHost({
-        host: {symbolicName: 'host-app'},
-        applications: [
-          {symbolicName: 'app-1', manifestUrl: new ManifestFixture({name: 'App 1'}).serve()},
-          {symbolicName: 'app-2', manifestUrl: new ManifestFixture({name: 'App 2'}).serve()},
-        ],
-      });
-
-      // Register capability
-      await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '*'}}, 'app-1');
-
-      // Expect app-1 to have an implicit intention because providing the capability
-      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', id: '5'}}, 'app-1')).toBeTrue();
-
-      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person'}}, 'app-1')).toBeFalse();
-      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'app-1')).toBeFalse();
-      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', id: '5', other: 'property'}}, 'app-1')).toBeFalse();
-
-      // Expect app-2 to not have an intention
-      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', id: '5'}}, 'app-2')).toBeFalse();
-    });
-
-    it(`should have an implicit intention for a capability having an optional qualifier ({entity: 'person', id: '?'})`, async () => {
-      await MicrofrontendPlatform.startHost({
-        host: {symbolicName: 'host-app'},
-        applications: [
-          {symbolicName: 'app-1', manifestUrl: new ManifestFixture({name: 'App 1'}).serve()},
-          {symbolicName: 'app-2', manifestUrl: new ManifestFixture({name: 'App 2'}).serve()},
-        ],
-      });
-
-      // Register capability
-      await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '?'}}, 'app-1');
-
-      // Expect app-1 to have an implicit intention because providing the capability
-      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', id: '5'}}, 'app-1')).toBeTrue();
-      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person'}}, 'app-1')).toBeTrue();
-
-      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'app-1')).toBeFalse();
-      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', id: '5', other: 'property'}}, 'app-1')).toBeFalse();
-
-      // Expect app-2 to not have an intention
-      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', id: '5'}}, 'app-2')).toBeFalse();
-    });
-
-    it(`should match an intention having an exact qualifier ({entity: 'person', id: '5'})`, async () => {
+    it(`should match an intention having an exact qualifier ({entity: 'person', mode: 'new'})`, async () => {
       await MicrofrontendPlatform.startHost({
         host: {symbolicName: 'host-app'},
         applications: [
@@ -120,21 +74,21 @@ describe('ManifestRegistry', () => {
       });
 
       // Register intention
-      await Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '5'}}, 'app-1');
+      await Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'app-1');
 
       // Expect app-1 to have an intention
-      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', id: '5'}}, 'app-1')).toBeTrue();
+      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'app-1')).toBeTrue();
 
-      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', id: '999'}}, 'app-1')).toBeFalse();
+      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', mode: 'edit'}}, 'app-1')).toBeFalse();
       expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person'}}, 'app-1')).toBeFalse();
       expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'app-1')).toBeFalse();
-      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', id: '5', other: 'property'}}, 'app-1')).toBeFalse();
+      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'app-1')).toBeFalse();
 
       // Expect app-2 to not have an intention
-      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', id: '5'}}, 'app-2')).toBeFalse();
+      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'app-2')).toBeFalse();
     });
 
-    it(`should match an intention having an asterisk wildcard qualifier ({entity: 'person', id: '*'})`, async () => {
+    it(`should match an intention having an asterisk wildcard qualifier ({entity: 'person', mode: '*'})`, async () => {
       await MicrofrontendPlatform.startHost({
         host: {symbolicName: 'host-app'},
         applications: [
@@ -144,17 +98,17 @@ describe('ManifestRegistry', () => {
       });
 
       // Register intention
-      await Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '*'}}, 'app-1');
+      await Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: '*'}}, 'app-1');
 
       // Expect app-1 to have an intention
-      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', id: '5'}}, 'app-1')).toBeTrue();
+      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'app-1')).toBeTrue();
 
       expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person'}}, 'app-1')).toBeFalse();
       expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'app-1')).toBeFalse();
-      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', id: '5', other: 'property'}}, 'app-1')).toBeFalse();
+      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'app-1')).toBeFalse();
 
       // Expect app-2 to not have an intention
-      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', id: '5'}}, 'app-2')).toBeFalse();
+      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'app-2')).toBeFalse();
     });
 
     it(`should match an intention having an any-more wildcard (**) qualifier ({entity: 'person', '*': '*'})`, async () => {
@@ -167,41 +121,18 @@ describe('ManifestRegistry', () => {
       });
 
       // Register intention
-      await Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {'entity': 'person', '*': '*'}}, 'app-1');
+      await Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', '*': '*'}}, 'app-1');
 
       // Expect app-1 to have an intention
-      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', id: '5'}}, 'app-1')).toBeTrue();
+      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'app-1')).toBeTrue();
 
       expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person'}}, 'app-1')).toBeTrue();
       expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'app-1')).toBeTrue();
-      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', id: '5', other: 'property'}}, 'app-1')).toBeTrue();
+      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'app-1')).toBeTrue();
       expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'company'}}, 'app-1')).toBeFalse();
 
       // Expect app-2 to not have an intention
-      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', id: '5'}}, 'app-2')).toBeFalse();
-    });
-
-    it(`should match an intention having an optional wildcard (?) qualifier ({entity: 'person', id: '?'})`, async () => {
-      await MicrofrontendPlatform.startHost({
-        host: {symbolicName: 'host-app'},
-        applications: [
-          {symbolicName: 'app-1', manifestUrl: new ManifestFixture({name: 'App 1'}).serve()},
-          {symbolicName: 'app-2', manifestUrl: new ManifestFixture({name: 'App 2'}).serve()},
-        ],
-      });
-
-      // Register intention
-      await Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '?'}}, 'app-1');
-
-      // Expect app-1 to have an intention
-      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', id: '5'}}, 'app-1')).toBeTrue();
-      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person'}}, 'app-1')).toBeTrue();
-
-      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'app-1')).toBeFalse();
-      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', id: '5', other: 'property'}}, 'app-1')).toBeFalse();
-
-      // Expect app-2 to not have an intention
-      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', id: '5'}}, 'app-2')).toBeFalse();
+      expect(Beans.get(ManifestRegistry).hasIntention({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'app-2')).toBeFalse();
     });
   });
 
@@ -213,12 +144,12 @@ describe('ManifestRegistry', () => {
         applications: [],
       });
 
-      expect(() => Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', id: '*'}}, 'host-app')).toThrowError(/IllegalQualifierError/);
+      expect(() => Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', mode: '*'}}, 'host-app')).toThrowError(/IllegalQualifierError/);
     });
 
     describe('implicit intention', () => {
 
-      it('should resolve to own private capability having an exact qualifier', async () => {
+      it(`should resolve to own private capability having the qualifier ({entity: 'person', mode: 'new'})`, async () => {
         await MicrofrontendPlatform.startHost({
           host: {symbolicName: 'host-app'},
           applications: [
@@ -228,57 +159,15 @@ describe('ManifestRegistry', () => {
         });
 
         // Register capability
-        const capabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '5'}}, 'app-1');
+        const capabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'app-1');
 
-        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', id: '5'}}, 'app-1').map(capabilityIdExtractFn)).toEqual([capabilityId]);
-        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', id: '999'}}, 'app-1')).toEqual([]);
+        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'app-1').map(capabilityIdExtractFn)).toEqual([capabilityId]);
+        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', mode: 'edit'}}, 'app-1')).toEqual([]);
         expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person'}}, 'app-1')).toEqual([]);
         expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'app-1')).toEqual([]);
-        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', id: '5', other: 'property'}}, 'app-1')).toEqual([]);
+        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'app-1')).toEqual([]);
 
-        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', id: '5'}}, 'app-2')).toEqual([]);
-      });
-
-      it('should resolve to own private capability having an asterisk wildcard (*) in the qualifier', async () => {
-        await MicrofrontendPlatform.startHost({
-          host: {symbolicName: 'host-app'},
-          applications: [
-            {symbolicName: 'app-1', manifestUrl: new ManifestFixture({name: 'App 1'}).serve()},
-            {symbolicName: 'app-2', manifestUrl: new ManifestFixture({name: 'App 2'}).serve()},
-          ],
-        });
-
-        // Register capability
-        const capabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '*'}}, 'app-1');
-
-        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', id: '5'}}, 'app-1').map(capabilityIdExtractFn)).toEqual([capabilityId]);
-        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', id: '999'}}, 'app-1').map(capabilityIdExtractFn)).toEqual([capabilityId]);
-        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person'}}, 'app-1')).toEqual([]);
-        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'app-1')).toEqual([]);
-        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', id: '5', other: 'property'}}, 'app-1')).toEqual([]);
-
-        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', id: '5'}}, 'app-2')).toEqual([]);
-      });
-
-      it('should resolve to own private capability having an optional wildcard (?) in the qualifier', async () => {
-        await MicrofrontendPlatform.startHost({
-          host: {symbolicName: 'host-app'},
-          applications: [
-            {symbolicName: 'app-1', manifestUrl: new ManifestFixture({name: 'App 1'}).serve()},
-            {symbolicName: 'app-2', manifestUrl: new ManifestFixture({name: 'App 2'}).serve()},
-          ],
-        });
-
-        // Register capability
-        const capabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '?'}}, 'app-1');
-
-        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', id: '5'}}, 'app-1').map(capabilityIdExtractFn)).toEqual([capabilityId]);
-        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', id: '999'}}, 'app-1').map(capabilityIdExtractFn)).toEqual([capabilityId]);
-        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person'}}, 'app-1').map(capabilityIdExtractFn)).toEqual([capabilityId]);
-        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'app-1')).toEqual([]);
-        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', id: '5', other: 'property'}}, 'app-1')).toEqual([]);
-
-        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', id: '5'}}, 'app-2')).toEqual([]);
+        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'app-2')).toEqual([]);
       });
 
       it('should not resolve to private capabilities of other applications', async () => {
@@ -291,18 +180,18 @@ describe('ManifestRegistry', () => {
         });
 
         // Register capabilities of app-1
-        await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'id1'}, private: true}, 'app-1');
-        await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'id2'}, private: true}, 'app-1');
-        await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'id3'}, private: true}, 'app-1');
+        await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}, private: true}, 'app-1');
+        await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'edit'}, private: true}, 'app-1');
+        await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'delete'}, private: true}, 'app-1');
 
         // Register capabilities of app-2 (public, private, implicit-private)
-        const capabilityId1 = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'id1'}, private: false}, 'app-2');
-        const capabilityId2 = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'id2'}, private: true}, 'app-2');
-        const capabilityId3 = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'id3'}}, 'app-2');
+        const capabilityId1 = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}, private: false}, 'app-2');
+        const capabilityId2 = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'edit'}, private: true}, 'app-2');
+        const capabilityId3 = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'delete'}}, 'app-2');
 
-        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', id: 'id1'}}, 'app-2').map(capabilityIdExtractFn)).toEqual([capabilityId1]);
-        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', id: 'id2'}}, 'app-2').map(capabilityIdExtractFn)).toEqual([capabilityId2]);
-        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', id: 'id3'}}, 'app-2').map(capabilityIdExtractFn)).toEqual([capabilityId3]);
+        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'app-2').map(capabilityIdExtractFn)).toEqual([capabilityId1]);
+        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', mode: 'edit'}}, 'app-2').map(capabilityIdExtractFn)).toEqual([capabilityId2]);
+        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', mode: 'delete'}}, 'app-2').map(capabilityIdExtractFn)).toEqual([capabilityId3]);
       });
 
       it('should not resolve to public capabilities of other applications', async () => {
@@ -315,24 +204,24 @@ describe('ManifestRegistry', () => {
         });
 
         // Register capabilities of app-1
-        await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'id1'}, private: false}, 'app-1');
-        await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'id2'}, private: false}, 'app-1');
-        await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'id3'}, private: false}, 'app-1');
+        await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}, private: false}, 'app-1');
+        await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'edit'}, private: false}, 'app-1');
+        await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'delete'}, private: false}, 'app-1');
 
         // Register capabilities of app-2 (public, private, implicit-private)
-        const capabilityId1 = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'id1'}, private: false}, 'app-2');
-        const capabilityId2 = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'id2'}, private: true}, 'app-2');
-        const capabilityId3 = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'id3'}}, 'app-2');
+        const capabilityId1 = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}, private: false}, 'app-2');
+        const capabilityId2 = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'edit'}, private: true}, 'app-2');
+        const capabilityId3 = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'delete'}}, 'app-2');
 
-        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', id: 'id1'}}, 'app-2').map(capabilityIdExtractFn)).toEqual([capabilityId1]);
-        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', id: 'id2'}}, 'app-2').map(capabilityIdExtractFn)).toEqual([capabilityId2]);
-        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', id: 'id3'}}, 'app-2').map(capabilityIdExtractFn)).toEqual([capabilityId3]);
+        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'app-2').map(capabilityIdExtractFn)).toEqual([capabilityId1]);
+        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', mode: 'edit'}}, 'app-2').map(capabilityIdExtractFn)).toEqual([capabilityId2]);
+        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', mode: 'delete'}}, 'app-2').map(capabilityIdExtractFn)).toEqual([capabilityId3]);
       });
     });
 
     describe('explicit intention', () => {
 
-      it('should resolve to public foreign capability having an exact qualifier', async () => {
+      it(`should resolve to public foreign capability having the qualifier ({entity: 'person', mode: 'new'})`, async () => {
         await MicrofrontendPlatform.startHost({
           host: {symbolicName: 'host-app'},
           applications: [
@@ -342,49 +231,12 @@ describe('ManifestRegistry', () => {
         });
 
         // Register capability of app-1
-        const capabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '5'}, private: false}, 'app-1');
+        const capabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}, private: false}, 'app-1');
 
         // Register intention of app-2
-        Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '5'}}, 'app-2');
+        Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'app-2');
 
-        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', id: '5'}}, 'app-2').map(capabilityIdExtractFn)).toEqual([capabilityId]);
-      });
-
-      it('should resolve to public foreign capability having an asterisk wildcard (*) in the qualifier', async () => {
-        await MicrofrontendPlatform.startHost({
-          host: {symbolicName: 'host-app'},
-          applications: [
-            {symbolicName: 'app-1', manifestUrl: new ManifestFixture({name: 'App 1'}).serve()},
-            {symbolicName: 'app-2', manifestUrl: new ManifestFixture({name: 'App 2'}).serve()},
-          ],
-        });
-
-        // Register capability of app-1
-        const capabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '*'}, private: false}, 'app-1');
-
-        // Register intention of app-2
-        Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '*'}}, 'app-2');
-
-        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', id: '5'}}, 'app-2').map(capabilityIdExtractFn)).toEqual([capabilityId]);
-      });
-
-      it('should resolve to public foreign capability having an optional wildcard (?) in the qualifier', async () => {
-        await MicrofrontendPlatform.startHost({
-          host: {symbolicName: 'host-app'},
-          applications: [
-            {symbolicName: 'app-1', manifestUrl: new ManifestFixture({name: 'App 1'}).serve()},
-            {symbolicName: 'app-2', manifestUrl: new ManifestFixture({name: 'App 2'}).serve()},
-          ],
-        });
-
-        // Register capability of app-1
-        const capabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: '?'}, private: false}, 'app-1');
-
-        // Register intention of app-2
-        Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: '?'}}, 'app-2');
-
-        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', id: '5'}}, 'app-2').map(capabilityIdExtractFn)).toEqual([capabilityId]);
-        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person'}}, 'app-2').map(capabilityIdExtractFn)).toEqual([capabilityId]);
+        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'app-2').map(capabilityIdExtractFn)).toEqual([capabilityId]);
       });
 
       it('should resolve to public (but not private) capabilities of other apps', async () => {
@@ -397,18 +249,18 @@ describe('ManifestRegistry', () => {
         });
 
         // Register capabilities of app-1
-        const publicCapabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'public'}, private: false}, 'app-1');
-        await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'private'}, private: true}, 'app-1');
-        await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', id: 'implicit-private'}}, 'app-1');
+        const publicCapabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'public'}, private: false}, 'app-1');
+        await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'private'}, private: true}, 'app-1');
+        await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'implicit-private'}}, 'app-1');
 
         // Register intentions of app-2
-        Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: 'public'}}, 'app-2');
-        Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: 'private'}}, 'app-2');
-        Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', id: 'implicit-private'}}, 'app-2');
+        Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: 'public'}}, 'app-2');
+        Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: 'private'}}, 'app-2');
+        Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: 'implicit-private'}}, 'app-2');
 
-        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', id: 'public'}}, 'app-2').map(capabilityIdExtractFn)).toEqual([publicCapabilityId]);
-        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', id: 'private'}}, 'app-2')).toEqual([]);
-        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', id: 'implicit-private'}}, 'app-2')).toEqual([]);
+        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', mode: 'public'}}, 'app-2').map(capabilityIdExtractFn)).toEqual([publicCapabilityId]);
+        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', mode: 'private'}}, 'app-2')).toEqual([]);
+        expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', mode: 'implicit-private'}}, 'app-2')).toEqual([]);
       });
     });
   });
@@ -419,7 +271,34 @@ describe('ManifestRegistry', () => {
       applications: [],
     });
 
-    await expectAsync(Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {'entity': 'person', '*': '*'}}, 'host-app')).toBeRejectedWithError(`[CapabilityRegisterError] Asterisk wildcard ('*') not allowed in the qualifier key.`);
+    await expectAsync(Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', '*': '*'}}, 'host-app')).toBeRejectedWithError(`[CapabilityRegisterError] Asterisk wildcard ('*') not allowed in the qualifier key.`);
+  });
+
+  it('should not allow registering a capability using the asterisk wildcard (*) in its qualifier', async () => {
+    await MicrofrontendPlatform.startHost({
+      host: {symbolicName: 'host-app'},
+      applications: [],
+    });
+
+    await expectAsync(Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: '*'}}, 'host-app')).toBeRejectedWithError(`[CapabilityRegisterError] Asterisk wildcard ('*') not allowed in the qualifier value. Use required params instead.`);
+  });
+
+  it('should not allow registering a capability using the optional wildcard (?) in its qualifier', async () => {
+    await MicrofrontendPlatform.startHost({
+      host: {symbolicName: 'host-app'},
+      applications: [],
+    });
+
+    await expectAsync(Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: '?'}}, 'host-app')).toBeRejectedWithError(`[CapabilityRegisterError] Optional wildcard ('?') not allowed in the qualifier value. Use optional params instead.`);
+  });
+
+  it('should not allow registering an intention using the optional wildcard (?) in its qualifier', async () => {
+    await MicrofrontendPlatform.startHost({
+      host: {symbolicName: 'host-app'},
+      applications: [],
+    });
+
+    await expect(() => Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: '?'}}, 'host-app')).toThrowError(`[IntentionRegisterError] Optional wildcard ('?') not allowed in the qualifier value. You should define optional params in the capability instead.`);
   });
 
   describe('Capability Params', () => {

--- a/projects/scion/microfrontend-platform/src/lib/host/message-broker/intent-subscription.registry.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/host/message-broker/intent-subscription.registry.spec.ts
@@ -119,21 +119,6 @@ describe('IntentSubscriptionRegistry', () => {
     expect(testee.subscriptions({intent: {type: 'menu-item', qualifier: {entity: 'customer'}}}).length).toBe(0);
   });
 
-  it('should match subscription {qualifier: {entity: \'?\'}}', () => {
-    const testee = Beans.get(IntentSubscriptionRegistry);
-
-    testee.register(new IntentSubscription({qualifier: {entity: '?'}}, 'subscriber#id', newClient()));
-    expect(testee.subscriptions().length).toBe(1);
-    expect(testee.subscriptions({intent: {type: 'microfrontend'}}).length).toBe(1);
-    expect(testee.subscriptions({intent: {type: 'microfrontend', qualifier: {}}}).length).toBe(1);
-    expect(testee.subscriptions({intent: {type: 'microfrontend', qualifier: {entity: 'product'}}}).length).toBe(1);
-    expect(testee.subscriptions({intent: {type: 'microfrontend', qualifier: {entity: 'customer'}}}).length).toBe(1);
-    expect(testee.subscriptions({intent: {type: 'menu-item'}}).length).toBe(1);
-    expect(testee.subscriptions({intent: {type: 'menu-item', qualifier: {}}}).length).toBe(1);
-    expect(testee.subscriptions({intent: {type: 'menu-item', qualifier: {entity: 'product'}}}).length).toBe(1);
-    expect(testee.subscriptions({intent: {type: 'menu-item', qualifier: {entity: 'customer'}}}).length).toBe(1);
-  });
-
   it('should match subscription {qualifier: {entity: \'*\'}}', () => {
     const testee = Beans.get(IntentSubscriptionRegistry);
 

--- a/projects/scion/microfrontend-platform/src/lib/host/message-broker/intent-subscription.registry.ts
+++ b/projects/scion/microfrontend-platform/src/lib/host/message-broker/intent-subscription.registry.ts
@@ -47,7 +47,7 @@ export class IntentSubscription extends MessageSubscription {
     if (this.selector.type && this.selector.type !== intent.type) {
       return false;
     }
-    if (this.selector.qualifier && !new QualifierMatcher(this.selector.qualifier, {evalAsterisk: true, evalOptional: true}).matches(intent.qualifier)) {
+    if (this.selector.qualifier && !new QualifierMatcher(this.selector.qualifier).matches(intent.qualifier)) {
       return false;
     }
     return true;

--- a/projects/scion/microfrontend-platform/src/lib/platform.model.ts
+++ b/projects/scion/microfrontend-platform/src/lib/platform.model.ts
@@ -141,13 +141,7 @@ export interface Capability {
    * The qualifier is a dictionary of arbitrary key-value pairs to differentiate capabilities of the same `type` and is like
    * an abstract description of the capability. It should include enough information to uniquely identify the capability.
    *
-   * Intents must exactly match the qualifier of the capability, if any. The capability qualifier allows using wildcards
-   * (such as `*` or `?`) to match multiple intents simultaneously.
-   *
-   * - **Asterisk wildcard character (`*`):**
-   *   Intents must contain such a property, but any value is allowed (except `null` or `undefined`). Use it like this: `{property: '*'}`
-   * - **Optional wildcard character (?):**\
-   *   Intents can contain such a property. Use it like this: `{property: '?'}`.
+   * Intents must exactly match the qualifier of the capability, if any.
    */
   qualifier?: Qualifier;
   /**
@@ -226,14 +220,12 @@ export interface Intention {
    * The qualifier is a dictionary of arbitrary key-value pairs to differentiate capabilities of the same `type`.
    *
    * The intention must exactly match the qualifier of the capability, if any. The intention qualifier allows using
-   * wildcards (such as `*` or `?`) to match multiple capabilities simultaneously.
+   * wildcards to match multiple capabilities simultaneously.
    *
    * In the intention, the following wildcards are supported:
    * - **Asterisk wildcard character (`*`):**\
    *   Matches capabilities with such a qualifier property no matter of its value (except `null` or `undefined`).
    *   Use it like this: `{property: '*'}`.
-   * - **Optional wildcard character (?):**\
-   *   Matches capabilities regardless of having or not having such a property. Use it like this: `{property: '?'}`.
    * - **Partial wildcard (`**`):**
    *   Matches capabilities even if having additional properties. Use it like this: `{'*': '*'}`.
    */

--- a/projects/scion/microfrontend-platform/src/lib/qualifier-matcher.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/qualifier-matcher.spec.ts
@@ -11,377 +11,123 @@ import {assertExactQualifier, QualifierMatcher} from './qualifier-matcher';
 
 describe('QualifierTester', () => {
 
-  describe('should match a pattern containing the asterisk wildcard (*)', () => {
+  it('should match a pattern containing the asterisk wildcard (*)', () => {
+      const matcher = new QualifierMatcher({entity: 'person', mode: '*'});
 
-    it('flags: evalOptional: true, evalAsterisk: true', async () => {
-      const matcher = new QualifierMatcher({entity: 'person', id: '*'}, {evalOptional: true, evalAsterisk: true});
-
-      expect(matcher.matches({entity: 'person', id: '5'})).toBeTrue();
-      expect(matcher.matches({entity: 'person', id: '*'})).toBeTrue();
-      expect(matcher.matches({entity: 'person', id: '?'})).toBeTrue();
+      expect(matcher.matches({entity: 'person', mode: 'new'})).toBeTrue();
+      expect(matcher.matches({entity: 'person', mode: '*'})).toBeTrue();
       expect(matcher.matches({entity: 'person'})).toBeFalse();
       expect(matcher.matches({entity: 'person', other: 'property'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '5', other: 'property'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '*', other: 'property'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '?', other: 'property'})).toBeFalse();
+      expect(matcher.matches({entity: 'person', mode: 'new', other: 'property'})).toBeFalse();
+      expect(matcher.matches({entity: 'person', mode: '*', other: 'property'})).toBeFalse();
       expect(matcher.matches({})).toBeFalse();
-    });
-
-    it('flags: evalOptional: true, evalAsterisk: false', async () => {
-      const matcher = new QualifierMatcher({entity: 'person', id: '*'}, {evalOptional: true, evalAsterisk: false});
-
-      expect(matcher.matches({entity: 'person', id: '5'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '*'})).toBeTrue();
-      expect(matcher.matches({entity: 'person', id: '?'})).toBeFalse();
-      expect(matcher.matches({entity: 'person'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', other: 'property'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '5', other: 'property'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '*', other: 'property'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '?', other: 'property'})).toBeFalse();
-      expect(matcher.matches({})).toBeFalse();
-      expect(matcher.matches(null)).toBeFalse();
-      expect(matcher.matches(undefined)).toBeFalse();
-    });
-
-    it('flags: evalOptional: false, evalAsterisk: true', async () => {
-      const matcher = new QualifierMatcher({entity: 'person', id: '*'}, {evalOptional: false, evalAsterisk: true});
-
-      expect(matcher.matches({entity: 'person', id: '5'})).toBeTrue();
-      expect(matcher.matches({entity: 'person', id: '*'})).toBeTrue();
-      expect(matcher.matches({entity: 'person', id: '?'})).toBeTrue();
-      expect(matcher.matches({entity: 'person'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', other: 'property'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '5', other: 'property'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '*', other: 'property'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '?', other: 'property'})).toBeFalse();
-      expect(matcher.matches({})).toBeFalse();
-      expect(matcher.matches(null)).toBeFalse();
-      expect(matcher.matches(undefined)).toBeFalse();
-    });
-
-    it('flags: evalOptional: false, evalAsterisk: false', async () => {
-      const matcher = new QualifierMatcher({entity: 'person', id: '*'}, {evalOptional: false, evalAsterisk: false});
-
-      expect(matcher.matches({entity: 'person', id: '5'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '*'})).toBeTrue();
-      expect(matcher.matches({entity: 'person', id: '?'})).toBeFalse();
-      expect(matcher.matches({entity: 'person'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', other: 'property'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '5', other: 'property'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '*', other: 'property'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '?', other: 'property'})).toBeFalse();
-      expect(matcher.matches({})).toBeFalse();
-      expect(matcher.matches(null)).toBeFalse();
-      expect(matcher.matches(undefined)).toBeFalse();
-    });
   });
 
-  describe('should match a pattern containing the asterisk wildcard (*) and the any-more wildcard (**)', () => {
+  it('should match a pattern containing the asterisk wildcard (*) and the any-more wildcard (**)', () => {
+      const matcher = new QualifierMatcher({entity: 'person', mode: '*', '*': '*'});
 
-    it('flags: evalOptional: true, evalAsterisk: true', async () => {
-      const matcher = new QualifierMatcher({'entity': 'person', 'id': '*', '*': '*'}, {evalOptional: true, evalAsterisk: true});
-
-      expect(matcher.matches({entity: 'person', id: '5'})).toBeTrue();
-      expect(matcher.matches({entity: 'person', id: '*'})).toBeTrue();
-      expect(matcher.matches({entity: 'person', id: '?'})).toBeTrue();
+      expect(matcher.matches({entity: 'person', mode: 'new'})).toBeTrue();
+      expect(matcher.matches({entity: 'person', mode: '*'})).toBeTrue();
       expect(matcher.matches({entity: 'person'})).toBeFalse();
       expect(matcher.matches({entity: 'person', other: 'property'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '5', other: 'property'})).toBeTrue();
-      expect(matcher.matches({entity: 'person', id: '*', other: 'property'})).toBeTrue();
-      expect(matcher.matches({entity: 'person', id: '?', other: 'property'})).toBeTrue();
+      expect(matcher.matches({entity: 'person', mode: 'new', other: 'property'})).toBeTrue();
+      expect(matcher.matches({entity: 'person', mode: '*', other: 'property'})).toBeTrue();
       expect(matcher.matches({})).toBeFalse();
       expect(matcher.matches(null)).toBeFalse();
       expect(matcher.matches(undefined)).toBeFalse();
-    });
-
-    it('flags: evalOptional: true, evalAsterisk: false', async () => {
-      const matcher = new QualifierMatcher({'entity': 'person', 'id': '*', '*': '*'}, {evalOptional: true, evalAsterisk: false});
-
-      expect(matcher.matches({entity: 'person', id: '5'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '*'})).toBeTrue();
-      expect(matcher.matches({entity: 'person', id: '?'})).toBeFalse();
-      expect(matcher.matches({entity: 'person'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', other: 'property'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '5', other: 'property'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '*', other: 'property'})).toBeTrue();
-      expect(matcher.matches({entity: 'person', id: '?', other: 'property'})).toBeFalse();
-      expect(matcher.matches({})).toBeFalse();
-      expect(matcher.matches(null)).toBeFalse();
-      expect(matcher.matches(undefined)).toBeFalse();
-    });
-
-    it('flags: evalOptional: false, evalAsterisk: true', async () => {
-      const matcher = new QualifierMatcher({'entity': 'person', 'id': '*', '*': '*'}, {evalOptional: false, evalAsterisk: true});
-
-      expect(matcher.matches({entity: 'person', id: '5'})).toBeTrue();
-      expect(matcher.matches({entity: 'person', id: '*'})).toBeTrue();
-      expect(matcher.matches({entity: 'person', id: '?'})).toBeTrue();
-      expect(matcher.matches({entity: 'person'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', other: 'property'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '5', other: 'property'})).toBeTrue();
-      expect(matcher.matches({entity: 'person', id: '*', other: 'property'})).toBeTrue();
-      expect(matcher.matches({entity: 'person', id: '?', other: 'property'})).toBeTrue();
-      expect(matcher.matches({})).toBeFalse();
-      expect(matcher.matches(null)).toBeFalse();
-      expect(matcher.matches(undefined)).toBeFalse();
-    });
-
-    it('flags: evalOptional: false, evalAsterisk: false', async () => {
-      const matcher = new QualifierMatcher({'entity': 'person', 'id': '*', '*': '*'}, {evalOptional: false, evalAsterisk: false});
-
-      expect(matcher.matches({entity: 'person', id: '5'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '*'})).toBeTrue();
-      expect(matcher.matches({entity: 'person', id: '?'})).toBeFalse();
-      expect(matcher.matches({entity: 'person'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', other: 'property'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '5', other: 'property'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '*', other: 'property'})).toBeTrue();
-      expect(matcher.matches({entity: 'person', id: '?', other: 'property'})).toBeFalse();
-      expect(matcher.matches({})).toBeFalse();
-      expect(matcher.matches(null)).toBeFalse();
-      expect(matcher.matches(undefined)).toBeFalse();
-    });
-  });
-
-  describe('should match a pattern containing the optional wildcard (?)', () => {
-
-    it('flags: evalOptional: true, evalAsterisk: true', async () => {
-      const matcher = new QualifierMatcher({entity: 'person', id: '?'}, {evalOptional: true, evalAsterisk: true});
-
-      expect(matcher.matches({entity: 'person', id: '5'})).toBeTrue();
-      expect(matcher.matches({entity: 'person', id: '*'})).toBeTrue();
-      expect(matcher.matches({entity: 'person', id: '?'})).toBeTrue();
-      expect(matcher.matches({entity: 'person'})).toBeTrue();
-      expect(matcher.matches({entity: 'person', other: 'property'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '5', other: 'property'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '*', other: 'property'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '?', other: 'property'})).toBeFalse();
-      expect(matcher.matches({})).toBeFalse();
-      expect(matcher.matches(null)).toBeFalse();
-      expect(matcher.matches(undefined)).toBeFalse();
-    });
-
-    it('flags: evalOptional: true, evalAsterisk: false', async () => {
-      const matcher = new QualifierMatcher({entity: 'person', id: '?'}, {evalOptional: true, evalAsterisk: false});
-
-      expect(matcher.matches({entity: 'person', id: '5'})).toBeTrue();
-      expect(matcher.matches({entity: 'person', id: '*'})).toBeTrue();
-      expect(matcher.matches({entity: 'person', id: '?'})).toBeTrue();
-      expect(matcher.matches({entity: 'person'})).toBeTrue();
-      expect(matcher.matches({entity: 'person', other: 'property'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '5', other: 'property'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '*', other: 'property'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '?', other: 'property'})).toBeFalse();
-      expect(matcher.matches({})).toBeFalse();
-      expect(matcher.matches(null)).toBeFalse();
-      expect(matcher.matches(undefined)).toBeFalse();
-    });
-
-    it('flags: evalOptional: false, evalAsterisk: true', async () => {
-      const matcher = new QualifierMatcher({entity: 'person', id: '?'}, {evalOptional: false, evalAsterisk: true});
-
-      expect(matcher.matches({entity: 'person', id: '5'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '*'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '?'})).toBeTrue();
-      expect(matcher.matches({entity: 'person'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', other: 'property'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '5', other: 'property'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '*', other: 'property'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '?', other: 'property'})).toBeFalse();
-      expect(matcher.matches({})).toBeFalse();
-      expect(matcher.matches(null)).toBeFalse();
-      expect(matcher.matches(undefined)).toBeFalse();
-    });
-
-    it('flags: evalOptional: false, evalAsterisk: false', async () => {
-      const matcher = new QualifierMatcher({entity: 'person', id: '?'}, {evalOptional: false, evalAsterisk: false});
-
-      expect(matcher.matches({entity: 'person', id: '5'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '*'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '?'})).toBeTrue();
-      expect(matcher.matches({entity: 'person'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', other: 'property'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '5', other: 'property'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '*', other: 'property'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '?', other: 'property'})).toBeFalse();
-      expect(matcher.matches({})).toBeFalse();
-      expect(matcher.matches(null)).toBeFalse();
-      expect(matcher.matches(undefined)).toBeFalse();
-    });
-  });
-
-  describe('should match a pattern containing the optional wildcard (?) and the any-more wildcard (**)', () => {
-
-    it('flags: evalOptional: true, evalAsterisk: true', async () => {
-      const matcher = new QualifierMatcher({'entity': 'person', 'id': '?', '*': '*'}, {evalOptional: true, evalAsterisk: true});
-
-      expect(matcher.matches({entity: 'person', id: '5'})).toBeTrue();
-      expect(matcher.matches({entity: 'person', id: '*'})).toBeTrue();
-      expect(matcher.matches({entity: 'person', id: '?'})).toBeTrue();
-      expect(matcher.matches({entity: 'person'})).toBeTrue();
-      expect(matcher.matches({entity: 'person', other: 'property'})).toBeTrue();
-      expect(matcher.matches({entity: 'person', id: '5', other: 'property'})).toBeTrue();
-      expect(matcher.matches({entity: 'person', id: '*', other: 'property'})).toBeTrue();
-      expect(matcher.matches({entity: 'person', id: '?', other: 'property'})).toBeTrue();
-      expect(matcher.matches({})).toBeFalse();
-      expect(matcher.matches(null)).toBeFalse();
-      expect(matcher.matches(undefined)).toBeFalse();
-    });
-
-    it('flags: evalOptional: true, evalAsterisk: false', async () => {
-      const matcher = new QualifierMatcher({'entity': 'person', 'id': '?', '*': '*'}, {evalOptional: true, evalAsterisk: false});
-
-      expect(matcher.matches({entity: 'person', id: '5'})).toBeTrue();
-      expect(matcher.matches({entity: 'person', id: '*'})).toBeTrue();
-      expect(matcher.matches({entity: 'person', id: '?'})).toBeTrue();
-      expect(matcher.matches({entity: 'person'})).toBeTrue();
-      expect(matcher.matches({entity: 'person', other: 'property'})).toBeTrue();
-      expect(matcher.matches({entity: 'person', id: '5', other: 'property'})).toBeTrue();
-      expect(matcher.matches({entity: 'person', id: '*', other: 'property'})).toBeTrue();
-      expect(matcher.matches({entity: 'person', id: '?', other: 'property'})).toBeTrue();
-      expect(matcher.matches({})).toBeFalse();
-      expect(matcher.matches(null)).toBeFalse();
-      expect(matcher.matches(undefined)).toBeFalse();
-    });
-
-    it('flags: evalOptional: false, evalAsterisk: true', async () => {
-      const matcher = new QualifierMatcher({'entity': 'person', 'id': '?', '*': '*'}, {evalOptional: false, evalAsterisk: true});
-
-      expect(matcher.matches({entity: 'person', id: '5'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '*'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '?'})).toBeTrue();
-      expect(matcher.matches({entity: 'person'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', other: 'property'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '5', other: 'property'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '*', other: 'property'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '?', other: 'property'})).toBeTrue();
-      expect(matcher.matches({})).toBeFalse();
-      expect(matcher.matches(null)).toBeFalse();
-      expect(matcher.matches(undefined)).toBeFalse();
-    });
-
-    it('flags: evalOptional: false, evalAsterisk: false', async () => {
-      const matcher = new QualifierMatcher({'entity': 'person', 'id': '?', '*': '*'}, {evalOptional: false, evalAsterisk: false});
-
-      expect(matcher.matches({entity: 'person', id: '5'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '*'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '?'})).toBeTrue();
-      expect(matcher.matches({entity: 'person'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', other: 'property'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '5', other: 'property'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '*', other: 'property'})).toBeFalse();
-      expect(matcher.matches({entity: 'person', id: '?', other: 'property'})).toBeTrue();
-      expect(matcher.matches({})).toBeFalse();
-      expect(matcher.matches(null)).toBeFalse();
-      expect(matcher.matches(undefined)).toBeFalse();
-    });
   });
 
   it('should match if the pattern is empty', async () => {
-    const matcher = new QualifierMatcher({}, {evalOptional: true, evalAsterisk: true});
+    const matcher = new QualifierMatcher({});
 
-    expect(matcher.matches({entity: 'person', id: '5'})).toBeFalse();
-    expect(matcher.matches({entity: 'person', id: '*'})).toBeFalse();
-    expect(matcher.matches({entity: 'person', id: '?'})).toBeFalse();
+    expect(matcher.matches({entity: 'person', mode: 'new'})).toBeFalse();
+    expect(matcher.matches({entity: 'person', mode: '*'})).toBeFalse();
     expect(matcher.matches({entity: 'person'})).toBeFalse();
     expect(matcher.matches({entity: 'person', other: 'property'})).toBeFalse();
-    expect(matcher.matches({entity: 'person', id: '5', other: 'property'})).toBeFalse();
-    expect(matcher.matches({entity: 'person', id: '*', other: 'property'})).toBeFalse();
-    expect(matcher.matches({entity: 'person', id: '?', other: 'property'})).toBeFalse();
+    expect(matcher.matches({entity: 'person', mode: 'new', other: 'property'})).toBeFalse();
+    expect(matcher.matches({entity: 'person', mode: '*', other: 'property'})).toBeFalse();
     expect(matcher.matches({})).toBeTrue();
     expect(matcher.matches(null)).toBeTrue();
     expect(matcher.matches(undefined)).toBeTrue();
   });
 
   it('should match if the pattern is `undefined`', async () => {
-    const matcher = new QualifierMatcher(undefined, {evalOptional: true, evalAsterisk: true});
+    const matcher = new QualifierMatcher(undefined);
 
-    expect(matcher.matches({entity: 'person', id: '5'})).toBeFalse();
-    expect(matcher.matches({entity: 'person', id: '*'})).toBeFalse();
-    expect(matcher.matches({entity: 'person', id: '?'})).toBeFalse();
+    expect(matcher.matches({entity: 'person', mode: 'new'})).toBeFalse();
+    expect(matcher.matches({entity: 'person', mode: '*'})).toBeFalse();
     expect(matcher.matches({entity: 'person'})).toBeFalse();
     expect(matcher.matches({entity: 'person', other: 'property'})).toBeFalse();
-    expect(matcher.matches({entity: 'person', id: '5', other: 'property'})).toBeFalse();
-    expect(matcher.matches({entity: 'person', id: '*', other: 'property'})).toBeFalse();
-    expect(matcher.matches({entity: 'person', id: '?', other: 'property'})).toBeFalse();
+    expect(matcher.matches({entity: 'person', mode: 'new', other: 'property'})).toBeFalse();
+    expect(matcher.matches({entity: 'person', mode: '*', other: 'property'})).toBeFalse();
     expect(matcher.matches({})).toBeTrue();
     expect(matcher.matches(null)).toBeTrue();
     expect(matcher.matches(undefined)).toBeTrue();
   });
 
   it('should match if the pattern is `null`', async () => {
-    const matcher = new QualifierMatcher(null, {evalOptional: true, evalAsterisk: true});
+    const matcher = new QualifierMatcher(null);
 
-    expect(matcher.matches({entity: 'person', id: '5'})).toBeFalse();
-    expect(matcher.matches({entity: 'person', id: '*'})).toBeFalse();
-    expect(matcher.matches({entity: 'person', id: '?'})).toBeFalse();
+    expect(matcher.matches({entity: 'person', mode: 'new'})).toBeFalse();
+    expect(matcher.matches({entity: 'person', mode: '*'})).toBeFalse();
     expect(matcher.matches({entity: 'person'})).toBeFalse();
     expect(matcher.matches({entity: 'person', other: 'property'})).toBeFalse();
-    expect(matcher.matches({entity: 'person', id: '5', other: 'property'})).toBeFalse();
-    expect(matcher.matches({entity: 'person', id: '*', other: 'property'})).toBeFalse();
-    expect(matcher.matches({entity: 'person', id: '?', other: 'property'})).toBeFalse();
+    expect(matcher.matches({entity: 'person', mode: 'new', other: 'property'})).toBeFalse();
+    expect(matcher.matches({entity: 'person', mode: '*', other: 'property'})).toBeFalse();
     expect(matcher.matches({})).toBeTrue();
     expect(matcher.matches(null)).toBeTrue();
     expect(matcher.matches(undefined)).toBeTrue();
   });
 
   it('should match if the pattern is empty and contains the any-more wildcard (**)', async () => {
-    const matcher = new QualifierMatcher({'*': '*'}, {evalOptional: true, evalAsterisk: true});
+    const matcher = new QualifierMatcher({'*': '*'});
 
-    expect(matcher.matches({entity: 'person', id: '5'})).toBeTrue();
-    expect(matcher.matches({entity: 'person', id: '*'})).toBeTrue();
-    expect(matcher.matches({entity: 'person', id: '?'})).toBeTrue();
+    expect(matcher.matches({entity: 'person', mode: 'new'})).toBeTrue();
+    expect(matcher.matches({entity: 'person', mode: '*'})).toBeTrue();
     expect(matcher.matches({entity: 'person'})).toBeTrue();
     expect(matcher.matches({entity: 'person', other: 'property'})).toBeTrue();
-    expect(matcher.matches({entity: 'person', id: '5', other: 'property'})).toBeTrue();
-    expect(matcher.matches({entity: 'person', id: '*', other: 'property'})).toBeTrue();
-    expect(matcher.matches({entity: 'person', id: '?', other: 'property'})).toBeTrue();
+    expect(matcher.matches({entity: 'person', mode: 'new', other: 'property'})).toBeTrue();
+    expect(matcher.matches({entity: 'person', mode: '*', other: 'property'})).toBeTrue();
     expect(matcher.matches({})).toBeTrue();
     expect(matcher.matches(null)).toBeTrue();
     expect(matcher.matches(undefined)).toBeTrue();
   });
 
   it('should match if the pattern is exact', () => {
-    const matcher = new QualifierMatcher({entity: 'person', id: '5'}, {evalOptional: true, evalAsterisk: true});
+    const matcher = new QualifierMatcher({entity: 'person', mode: 'new'});
 
-    expect(matcher.matches({entity: 'person', id: '5'})).toBeTrue();
-    expect(matcher.matches({entity: 'person', id: '*'})).toBeFalse();
-    expect(matcher.matches({entity: 'person', id: '?'})).toBeFalse();
+    expect(matcher.matches({entity: 'person', mode: 'new'})).toBeTrue();
+    expect(matcher.matches({entity: 'person', mode: '*'})).toBeFalse();
     expect(matcher.matches({entity: 'person'})).toBeFalse();
     expect(matcher.matches({entity: 'person', other: 'property'})).toBeFalse();
-    expect(matcher.matches({entity: 'person', id: '5', other: 'property'})).toBeFalse();
-    expect(matcher.matches({entity: 'person', id: '*', other: 'property'})).toBeFalse();
-    expect(matcher.matches({entity: 'person', id: '?', other: 'property'})).toBeFalse();
+    expect(matcher.matches({entity: 'person', mode: 'new', other: 'property'})).toBeFalse();
+    expect(matcher.matches({entity: 'person', mode: '*', other: 'property'})).toBeFalse();
     expect(matcher.matches({})).toBeFalse();
     expect(matcher.matches(null)).toBeFalse();
     expect(matcher.matches(undefined)).toBeFalse();
   });
 
   it('should match if the pattern is exact and contains the any-more wildcard (**)', () => {
-    const matcher = new QualifierMatcher({'entity': 'person', 'id': '5', '*': '*'}, {evalOptional: true, evalAsterisk: true});
+    const matcher = new QualifierMatcher({entity: 'person', mode: 'new', '*': '*'});
 
-    expect(matcher.matches({entity: 'person', id: '5'})).toBeTrue();
-    expect(matcher.matches({entity: 'person', id: '*'})).toBeFalse();
-    expect(matcher.matches({entity: 'person', id: '?'})).toBeFalse();
+    expect(matcher.matches({entity: 'person', mode: 'new'})).toBeTrue();
+    expect(matcher.matches({entity: 'person', mode: '*'})).toBeFalse();
     expect(matcher.matches({entity: 'person'})).toBeFalse();
     expect(matcher.matches({entity: 'person', other: 'property'})).toBeFalse();
-    expect(matcher.matches({entity: 'person', id: '5', other: 'property'})).toBeTrue();
-    expect(matcher.matches({entity: 'person', id: '*', other: 'property'})).toBeFalse();
-    expect(matcher.matches({entity: 'person', id: '?', other: 'property'})).toBeFalse();
+    expect(matcher.matches({entity: 'person', mode: 'new', other: 'property'})).toBeTrue();
+    expect(matcher.matches({entity: 'person', mode: '*', other: 'property'})).toBeFalse();
     expect(matcher.matches({})).toBeFalse();
     expect(matcher.matches(null)).toBeFalse();
     expect(matcher.matches(undefined)).toBeFalse();
   });
 
   it('should throw if the qualifier is not exact', () => {
-    expect(() => assertExactQualifier({entity: 'person', id: '5'})).not.toThrowError(/IllegalQualifierError/);
-    expect(() => assertExactQualifier({entity: 'person', id: '*'})).toThrowError(/IllegalQualifierError/);
-    expect(() => assertExactQualifier({entity: 'person', id: '?'})).toThrowError(/IllegalQualifierError/);
+    expect(() => assertExactQualifier({entity: 'person', mode: 'new'})).not.toThrowError(/IllegalQualifierError/);
+    expect(() => assertExactQualifier({entity: 'person', mode: '*'})).toThrowError(/IllegalQualifierError/);
     expect(() => assertExactQualifier({entity: 'person'})).not.toThrowError(/IllegalQualifierError/);
     expect(() => assertExactQualifier({entity: 'person', other: 'property'})).not.toThrowError(/IllegalQualifierError/);
-    expect(() => assertExactQualifier({entity: 'person', id: '5', other: 'property'})).not.toThrowError(/IllegalQualifierError/);
-    expect(() => assertExactQualifier({entity: 'person', id: '*', other: 'property'})).toThrowError(/IllegalQualifierError/);
-    expect(() => assertExactQualifier({entity: 'person', id: '?', other: 'property'})).toThrowError(/IllegalQualifierError/);
+    expect(() => assertExactQualifier({entity: 'person', mode: 'new', other: 'property'})).not.toThrowError(/IllegalQualifierError/);
+    expect(() => assertExactQualifier({entity: 'person', mode: '*', other: 'property'})).toThrowError(/IllegalQualifierError/);
     expect(() => assertExactQualifier({})).not.toThrowError(/IllegalQualifierError/);
     expect(() => assertExactQualifier(null)).not.toThrowError(/IllegalQualifierError/);
     expect(() => assertExactQualifier(undefined)).not.toThrowError(/IllegalQualifierError/);

--- a/projects/scion/microfrontend-platform/src/lib/qualifier-matcher.ts
+++ b/projects/scion/microfrontend-platform/src/lib/qualifier-matcher.ts
@@ -17,18 +17,15 @@ export class QualifierMatcher {
 
   private readonly _pattern: Qualifier;
   private readonly _patternKeys: string[];
-  private readonly _flags: Flags;
 
   /**
    * Constructs a matcher that will match given qualifiers against a pattern.
    *
    * @param pattern - Pattern to match qualifiers. If `null` or `undefined`, uses an empty qualifier pattern.
-   * @param flags   - Controls how to match qualifiers.
    */
-  constructor(pattern: Qualifier | null | undefined, flags: Flags) {
+  constructor(pattern: Qualifier | null | undefined) {
     this._pattern = pattern || {};
     this._patternKeys = Object.keys(this._pattern);
-    this._flags = flags;
   }
 
   /**
@@ -37,7 +34,7 @@ export class QualifierMatcher {
   public matches(qualifier: Qualifier | null | undefined): boolean {
     const testee = qualifier || {};
     const testeeKeys = Object.keys(testee);
-    const {_patternKeys: patternKeys, _pattern: pattern, _flags: flags} = this;
+    const {_patternKeys: patternKeys, _pattern: pattern} = this;
 
     // Test if the testee has no additional entries
     if (!patternKeys.includes('*') && testeeKeys.some(key => !patternKeys.includes(key))) {
@@ -50,10 +47,7 @@ export class QualifierMatcher {
         if (pattern[key] === testee[key]) {
           return true;
         }
-        if (flags.evalOptional && pattern[key] === '?') {
-          return true;
-        }
-        if (flags.evalAsterisk && pattern[key] === '*' && testee[key] !== undefined && testee[key] !== null) {
+        if (pattern[key] === '*' && testee[key] !== undefined && testee[key] !== null) {
           return true;
         }
         return false;
@@ -76,18 +70,4 @@ export function assertExactQualifier(qualifier: Qualifier | null | undefined): v
   if (Object.entries(qualifier).some(([key, value]) => key === '*' || value === '*' || value === '?')) {
     throw Error(`[IllegalQualifierError] Intent qualifier must not contain wildcards. [qualifier='${JSON.stringify(qualifier)}']`);
   }
-}
-
-/**
- * Controls how to match qualifiers.
- */
-export interface Flags {
-  /**
-   * Flag to enable wildcard matching. If `false`, the asterisk wildcard character (`*`) is interpreted as value.
-   */
-  evalAsterisk: boolean;
-  /**
-   * Flag to enable optional qualifier entry matching. If `false`, the question mark wildcard character (`?`) is interpreted as value.
-   */
-  evalOptional: boolean;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/SchweizerischeBundesbahnen/scion-microfrontend-platform/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added
- [x] Docs have been added or updated


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Fix
- [x] Feature
- [ ] Documentation
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance (changes that improve performance)
- [ ] Test (adding missing tests, refactoring tests; no production code change)
- [ ] Chore (other changes like formatting, updating the license, removal of deprecations, etc)
- [ ] Deps (changes related to updating dependencies)
- [ ] CI (changes to our CI configuration files and scripts)
- [ ] Revert (revert of a previous commit)
- [ ] Release (publish a new release)
- [ ] Other... Please describe:

## Issue

Issue Number: #163 

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

Dropping support for wildcard capability qualifiers and optional wildcard intention qualifiers introduced a breaking change in the Intention API.

To migrate, use required parameters instead of asterisk wildcard capability qualifiers and optional parameters instead of optional wildcard capability / intention qualifiers.


## Other information
