### PR TITLE
fix(platform/host): use secondary origin in addition to application origin as allowed origins

### DIFF
--- a/docs/adoc/microfrontend-platform-developer-guide/chapters/configuration/configuration.adoc
+++ b/docs/adoc/microfrontend-platform-developer-guide/chapters/configuration/configuration.adoc
@@ -154,13 +154,13 @@ a| `string`
 
 See <<objects::manifest,Manifest>> for an overview of the properties of the manifest.
 
-| messageOrigin
+| secondaryOrigin
 a| `string`
 | no
 |
-| Specifies the origin where message from this application must originate from. Messages of a different origin will be rejected. If not set, the origin is derived from the manifest URL or the base URL as specified in the manifest file.
+| Specifies an additional origin (in addition to the origin of the application) from which the application is allowed to connect to the platform.
 
-Setting a different origin may be necessary if, for example, integrating microfrontends into a rich client, allowing an integrator to bridge messages to a remote host.
+By default, if not set, the application is allowed to connect from the origin of the manifest URL or the base URL as specified in the manifest file. Setting an additional origin may be necessary if, for example, integrating microfrontends into a rich client, enabling an integrator to bridge messages between clients and host across browser boundaries.
 
 | [[objects::application-config:manifestLoadTimeout]]manifestLoadTimeout
 a| `number`

--- a/projects/scion/microfrontend-platform/src/lib/client/messaging/messaging.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/client/messaging/messaging.spec.ts
@@ -628,40 +628,6 @@ describe('Messaging', () => {
     expect(replyCaptor.hasErrored()).withContext('hasErrored').toBeFalse();
   });
 
-  it('should reject a client connect attempt if the app is not registered', async () => {
-    await MicrofrontendPlatform.startHost({applications: []}); // no app is registered
-
-    const microfrontendFixture = registerFixture(new MicrofrontendFixture());
-    const script = microfrontendFixture.insertIframe().loadScript('./lib/client/messaging/messaging.script.ts', 'connectToHost', {symbolicName: 'bad-client'});
-
-    await expectAsync(script).toBeRejectedWithError(/\[MessageClientConnectError] Client connect attempt rejected by the message broker: Unknown client./);
-  });
-
-  it('should reject a client connect attempt if the client\'s origin is different to the registered app origin', async () => {
-    await MicrofrontendPlatform.startHost({
-      applications: [
-        {
-          symbolicName: 'client',
-          manifestUrl: new ManifestFixture({name: 'Client', baseUrl: 'http://app-origin'}).serve(),
-        },
-      ],
-    });
-
-    const microfrontendFixture = registerFixture(new MicrofrontendFixture());
-    // Client connects under karma test runner origin, but is registered under `http://app-origin`.
-    const script = microfrontendFixture.insertIframe().loadScript('./lib/client/messaging/messaging.script.ts', 'connectToHost', {symbolicName: 'client'});
-
-    await expectAsync(script).toBeRejectedWithError(/\[MessageClientConnectError] Client connect attempt blocked by the message broker: Wrong origin./);
-  });
-
-  it('should reject startup promise if the message broker cannot be discovered', async () => {
-    const loggerSpy = getLoggerSpy('error');
-    const startup = MicrofrontendPlatform.connectToHost('client-app', {brokerDiscoverTimeout: 250});
-    await expectPromise(startup).toReject(/MicrofrontendPlatformStartupError/);
-
-    await expect(loggerSpy).toHaveBeenCalledWith('[GatewayError] Message broker not discovered within 250ms. Messages cannot be published or received.');
-  });
-
   it('should not error with `ClientConnectError` when starting the platform host and if initializers in runlevel 0 take a long time to complete, e.g., to fetch manifests', async () => {
     const loggerSpy = getLoggerSpy('error');
     const initializerDuration = 1000;

--- a/projects/scion/microfrontend-platform/src/lib/host/application-config.ts
+++ b/projects/scion/microfrontend-platform/src/lib/host/application-config.ts
@@ -25,12 +25,14 @@ export interface ApplicationConfig {
    */
   manifestUrl: string;
   /**
-   * Specifies the origin where message from this application must originate from. Messages of a different origin will be rejected.
-   * If not set, the origin is derived from the manifest URL or the base URL as specified in the manifest file. Setting a different
-   * origin may be necessary if, for example, integrating microfrontends into a rich client, allowing an integrator to bridge
-   * messages to a remote host.
+   * Specifies an additional origin (in addition to the origin of the application) from which the application is allowed
+   * to connect to the platform.
+   *
+   * By default, if not set, the application is allowed to connect from the origin of the manifest URL or the base URL as
+   * specified in the manifest file. Setting an additional origin may be necessary if, for example, integrating microfrontends
+   * into a rich client, enabling an integrator to bridge messages between clients and host across browser boundaries.
    */
-  messageOrigin?: string;
+  secondaryOrigin?: string;
   /**
    * Maximum time (in milliseconds) that the host waits until the manifest for this application is loaded.
    *

--- a/projects/scion/microfrontend-platform/src/lib/host/application-registry.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/host/application-registry.spec.ts
@@ -193,4 +193,24 @@ describe('ApplicationRegistry', () => {
     expect(registry.getApplication('app').name).toEqual('app');
     expect(registry.getApplication('app').symbolicName).toEqual('app');
   });
+
+  it('should set the application\'s manifest origin as allowed message origin', async () => {
+    await registry.registerApplication({symbolicName: 'app', manifestUrl: 'https://app.com/manifest'}, {name: 'App'});
+    expect(registry.getApplication('app').allowedMessageOrigins).toEqual(new Set().add('https://app.com'));
+  });
+
+  it('should set the application\'s base origin as allowed message origin', async () => {
+    await registry.registerApplication({symbolicName: 'app', manifestUrl: 'https://app.com/manifest'}, {name: 'App', baseUrl: 'https://primary.app.com'});
+    expect(registry.getApplication('app').allowedMessageOrigins).toEqual(new Set().add('https://primary.app.com'));
+  });
+
+  it('should add secondary origin to the allowed message origins (1/2)', async () => {
+    await registry.registerApplication({symbolicName: 'app', manifestUrl: 'https://app.com/manifest', secondaryOrigin: 'https://secondary.app.com'}, {name: 'App'});
+    expect(registry.getApplication('app').allowedMessageOrigins).toEqual(new Set().add('https://app.com').add('https://secondary.app.com'));
+  });
+
+  it('should add secondary origin to the allowed message origins (2/2)', async () => {
+    await registry.registerApplication({symbolicName: 'app', manifestUrl: 'https://app.com/manifest', secondaryOrigin: 'https://secondary.app.com'}, {name: 'App', baseUrl: 'https://primary.app.com'});
+    expect(registry.getApplication('app').allowedMessageOrigins).toEqual(new Set().add('https://primary.app.com').add('https://secondary.app.com'));
+  });
 });

--- a/projects/scion/microfrontend-platform/src/lib/host/client-registry/client.registry.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/host/client-registry/client.registry.spec.ts
@@ -80,6 +80,6 @@ describe('ClientRegistry', () => {
 
   function newClient(clientId: string, appSymbolicName: string): Client {
     const application: Partial<ɵApplication> = {symbolicName: appSymbolicName};
-    return new ɵClient(clientId, {} as Window, application as ɵApplication, Beans.get(ɵVERSION));
+    return new ɵClient(clientId, {} as Window, 'origin', application as ɵApplication, Beans.get(ɵVERSION));
   }
 });

--- a/projects/scion/microfrontend-platform/src/lib/host/client-registry/client.ts
+++ b/projects/scion/microfrontend-platform/src/lib/host/client-registry/client.ts
@@ -27,6 +27,11 @@ export interface Client {
   readonly window: Window;
 
   /**
+   * The origin of this client; is one of {@link ɵApplication.allowedMessageOrigins}.
+   */
+  readonly origin: string;
+
+  /**
    * The application this client belongs to.
    */
   readonly application: ɵApplication;

--- a/projects/scion/microfrontend-platform/src/lib/host/client-registry/ɵclient.ts
+++ b/projects/scion/microfrontend-platform/src/lib/host/client-registry/ɵclient.ts
@@ -29,6 +29,7 @@ export class ɵClient implements Client {
 
   constructor(public readonly id: string,
               public readonly window: Window,
+              public readonly origin: string,
               public readonly application: ɵApplication,
               version: string) {
     this.version = version ?? '0.0.0';

--- a/projects/scion/microfrontend-platform/src/lib/platform.model.ts
+++ b/projects/scion/microfrontend-platform/src/lib/platform.model.ts
@@ -70,10 +70,6 @@ export interface Application {
    */
   baseUrl: string;
   /**
-   * Specifies the origin where message from this application must originate from. Messages of a different origin will be rejected.
-   */
-  messageOrigin: string;
-  /**
    * URL to the manifest of this application.
    */
   manifestUrl: string;


### PR DESCRIPTION
Previously, configuring a secondary origin replaced the application's origin as allowed origin. This was not correct. Instead, the secondary origin should be an additionally allowed origin.

This feature was introduced for integrating microfrontends into a rich client to bridge messages between clients and host across browser boundaries. However, by replacing the origin, activators could no longer connect to the host.


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/SchweizerischeBundesbahnen/scion-microfrontend-platform/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added
- [x] Docs have been added or updated


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance (changes that improve performance)
- [ ] Test (adding missing tests, refactoring tests; no production code change)
- [ ] Chore (other changes like formatting, updating the license, removal of deprecations, etc)
- [ ] Deps (changes related to updating dependencies)
- [ ] CI (changes to our CI configuration files and scripts)
- [ ] Revert (revert of a previous commit)
- [ ] Release (publish a new release)
- [ ] Other... Please describe:

## Issue

Issue Number: #197 

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

Property for configuring a custom message origin has been renamed from `messageOrigin` to `secondaryOrigin`. This breaking change only refers to the host.

To migrate, configure the additionally allowed origin via the `secondaryOrigin` property instead of `messageOrigin`, as follows:

```ts
await MicrofrontendPlatform.startHost({
  applications: [
    {symbolicName: 'client', manifestUrl: 'https://app/manifest.json', secondaryOrigin: 'https://secondary'},
  ],
});
```