### PR TITLE
fix(platform): do not break clients not supporting the ping liveness protocol

### DIFF
--- a/projects/scion/microfrontend-platform/src/lib/client/client-disconnect.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/client/client-disconnect.spec.ts
@@ -243,7 +243,7 @@ describe('MicrofrontendPlatform', () => {
     const clientRegistry = Beans.get(ClientRegistry);
 
     // Load client (disconnectOnUnloadDisabled: true)
-    await microfrontendFixture.loadScript('./lib/client/client-disconnect.script.ts', 'connectToHost', {symbolicName: 'client', disconnectOnUnloadDisabled: true});
+    await microfrontendFixture.loadScript('./lib/client/client-disconnect.script.ts', 'connectToHost', {symbolicName: 'client', disconnectOnUnloadDisabled: true, version: '1.0.0-rc.11'});
     const clientId = await getClientId(microfrontendFixture);
     expect(clientRegistry.getByClientId(clientId)).withContext('expected "client" to be CONNECTED').toBeDefined();
 
@@ -276,7 +276,7 @@ describe('MicrofrontendPlatform', () => {
     const clientRegistry = Beans.get(ClientRegistry);
 
     // Load client (disconnectOnUnloadDisabled: true)
-    await microfrontendFixture.loadScript('./lib/client/client-disconnect.script.ts', 'connectToHost', {symbolicName: 'client', disconnectOnUnloadDisabled: true});
+    await microfrontendFixture.loadScript('./lib/client/client-disconnect.script.ts', 'connectToHost', {symbolicName: 'client', disconnectOnUnloadDisabled: true, version: '1.0.0-rc.11'});
     const clientId = await getClientId(microfrontendFixture);
 
     // Expect client to be connected

--- a/projects/scion/microfrontend-platform/src/lib/deprecation-warnings.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/deprecation-warnings.spec.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2018-2020 Swiss Federal Railways
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import {MicrofrontendPlatform} from './microfrontend-platform';
+import {MicrofrontendFixture} from './testing/microfrontend-fixture/microfrontend-fixture';
+import {ManifestFixture} from './testing/manifest-fixture/manifest-fixture';
+import {Beans} from '@scion/toolkit/bean-manager';
+import {installLoggerSpies, readConsoleLog} from './testing/spec.util.spec';
+import {ɵVERSION} from './platform.model';
+
+describe('Deprecated APIs', () => {
+
+  const disposables = new Set<Disposable>();
+
+  beforeEach(async () => {
+    await MicrofrontendPlatform.destroy();
+    installLoggerSpies();
+  });
+
+  afterEach(async () => {
+    await MicrofrontendPlatform.destroy();
+    disposables.forEach(disposable => disposable());
+  });
+
+  it('should warn if client does not support liveness probes introduced in version "1.0.0-rc.11"', async () => {
+    Beans.register(ɵVERSION, {useValue: '1.0.0'});
+
+    await MicrofrontendPlatform.startHost({
+      applications: [
+        {
+          symbolicName: 'app',
+          manifestUrl: new ManifestFixture({name: 'App'}).serve(),
+        },
+      ],
+    });
+
+    const microfrontendFixture = registerFixture(new MicrofrontendFixture()).insertIframe();
+    await microfrontendFixture.loadScript('./lib/version.script.ts', 'connectToHost', {symbolicName: 'app', version: '1.0.0-rc.10'});
+
+    // Assert deprecation warning
+    expect(readConsoleLog('warn', {filter: /\[DEPRECATION]/})).toEqual(jasmine.arrayContaining([
+      `[DEPRECATION][CD981D7] Application "app" is using a legacy liveness probe protocol. Please update @scion/microfrontend-platform to version '1.0.0'. Legacy support will be dropped in version '2.0.0'.`,
+    ]));
+  });
+
+  it('should warn if client does not support intent subscription protocol introduced in version "1.0.0-rc.8"', async () => {
+    Beans.register(ɵVERSION, {useValue: '1.0.0'});
+
+    await MicrofrontendPlatform.startHost({
+      applications: [
+        {
+          symbolicName: 'app',
+          manifestUrl: new ManifestFixture({name: 'App'}).serve(),
+        },
+      ],
+    });
+
+    const microfrontendFixture = registerFixture(new MicrofrontendFixture()).insertIframe();
+    await microfrontendFixture.loadScript('./lib/version.script.ts', 'connectToHost', {symbolicName: 'app', version: '1.0.0-rc.7'});
+
+    // Assert deprecation warning
+    expect(readConsoleLog('warn', {filter: /\[DEPRECATION]/})).toEqual(jasmine.arrayContaining([
+      `[DEPRECATION][FE93C94] Application "app" is using a legacy protocol for subscribing to intents. Please update @scion/microfrontend-platform to version '1.0.0'. Legacy support will be dropped in version '2.0.0'.`,
+    ]));
+  });
+
+  it('should warn if client does not support request-response communication protocol introduced in version "1.0.0-rc.9"', async () => {
+    Beans.register(ɵVERSION, {useValue: '1.0.0'});
+
+    await MicrofrontendPlatform.startHost({
+      applications: [
+        {
+          symbolicName: 'app',
+          manifestUrl: new ManifestFixture({name: 'App'}).serve(),
+        },
+      ],
+    });
+
+    const microfrontendFixture = registerFixture(new MicrofrontendFixture()).insertIframe();
+    await microfrontendFixture.loadScript('./lib/version.script.ts', 'connectToHost', {symbolicName: 'app', version: '1.0.0-rc.7'});
+
+    // Assert deprecation warning
+    expect(readConsoleLog('warn', {filter: /\[DEPRECATION]/})).toEqual(jasmine.arrayContaining([
+      `[DEPRECATION][F6DC38E] Application "app" is using a legacy request-response communication protocol. Please update @scion/microfrontend-platform to version '1.0.0'. Legacy support will be dropped in version '2.0.0'.`,
+    ]));
+  });
+
+  /**
+   * Registers the fixture for destruction after test execution.
+   */
+  function registerFixture(fixture: MicrofrontendFixture): MicrofrontendFixture {
+    disposables.add(() => fixture.removeIframe());
+    return fixture;
+  }
+});
+
+type Disposable = () => void;

--- a/projects/scion/microfrontend-platform/src/lib/host/client-registry/client.ts
+++ b/projects/scion/microfrontend-platform/src/lib/host/client-registry/client.ts
@@ -51,13 +51,17 @@ export interface Client {
    */
   readonly deprecations: {
     /**
-     * @deprecated since version 1.0.0-rc.8; Legacy support will be removed in version 1.0.0.
+     * @deprecated since version 1.0.0-rc.8; Legacy support will be removed in version 2.0.0.
      */
-    legacyIntentSubscriptionApi: boolean;
+    legacyIntentSubscriptionProtocol: boolean;
     /**
-     * @deprecated since version 1.0.0-rc.9; Legacy support will be removed in version 1.0.0.
+     * @deprecated since version 1.0.0-rc.9; Legacy support will be removed in version 2.0.0.
      */
-    legacyRequestResponseSubscriptionApi: boolean;
+    legacyRequestResponseSubscriptionProtocol: boolean;
+    /**
+     * @deprecated since version 1.0.0-rc.11; Legacy support will be removed in version 2.0.0.
+     */
+    legacyHeartbeatLivenessProtocol: boolean;
   };
 
   /**

--- a/projects/scion/microfrontend-platform/src/lib/version.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/version.spec.ts
@@ -71,27 +71,6 @@ describe('MicrofrontendPlatform', () => {
     ]));
   });
 
-  it('should warn if client does not support liveness ping introduced in version "1.0.0-rc.11"', async () => {
-    Beans.register(ɵVERSION, {useValue: '1.0.0'});
-
-    await MicrofrontendPlatform.startHost({
-      applications: [
-        {
-          symbolicName: 'client',
-          manifestUrl: new ManifestFixture({name: 'Client'}).serve(),
-        },
-      ],
-    });
-
-    const microfrontendFixture = registerFixture(new MicrofrontendFixture()).insertIframe();
-    await microfrontendFixture.loadScript('./lib/version.script.ts', 'connectToHost', {symbolicName: 'client', version: '1.0.0-beta.20'});
-
-    // Assert version mismatch warning
-    expect(readConsoleLog('warn', {filter: /\[VersionMismatch]/})).toEqual(jasmine.arrayContaining([
-      `[VersionMismatch] Since '@scion/microfrontend-platform@1.0.0-rc.11', connected clients must reply to pings to indicate liveness. Please upgrade @scion/microfrontend-platform of application 'client' from version '1.0.0-beta.20' to version '1.0.0'.`,
-    ]));
-  });
-
   it('should resolve the version of the SCION Microfronted Platform used by applications', async () => {
     await MicrofrontendPlatform.startHost({
       applications: [

--- a/projects/scion/microfrontend-platform/src/lib/ɵmessaging.model.ts
+++ b/projects/scion/microfrontend-platform/src/lib/ɵmessaging.model.ts
@@ -121,6 +121,10 @@ export interface ConnackMessage {
    * Unique id assigned to the client by the broker. Is only set on success.
    */
   clientId?: string;
+  /**
+   * @deprecated since version 1.0.0-rc.11; Legacy support will be removed in version 2.0.0.
+   */
+  heartbeatInterval?: number;
 }
 
 export interface SubscribeCommand extends Message {


### PR DESCRIPTION
Clients older than version `1.0.0-rc.11` expect the host to include the heartbeat interval in the connect acknowledgment. If not, they would send a heartbeat constantly, thus overloading the message bus. Since they do not understand the new protocol, they will also not respond to liveness pings.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/SchweizerischeBundesbahnen/scion-microfrontend-platform/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added
- [ ] Docs have been added or updated


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance (changes that improve performance)
- [ ] Test (adding missing tests, refactoring tests; no production code change)
- [ ] Chore (other changes like formatting, updating the license, removal of deprecations, etc)
- [ ] Deps (changes related to updating dependencies)
- [ ] CI (changes to our CI configuration files and scripts)
- [ ] Revert (revert of a previous commit)
- [ ] Release (publish a new release)
- [ ] Other... Please describe:

## Issue

Issue Number: #178 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
