### PR TITLE
fix(devtools): do not fall-through other types in `EmptyIfNullPipe`

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ SCION Microfrontend Platform enables you to successfully implement a framework-a
 ***
 
 
-[![Project version](https://img.shields.io/npm/v/@scion/microfrontend-platform.svg)][link-download]
-[![Project version](https://img.shields.io/npm/v/@scion/microfrontend-platform/next.svg)][link-download]
+[![@scion/microfrontend-platform version](https://img.shields.io/npm/v/@scion/microfrontend-platform/latest?label=%40scion%2Fmicrofrontend-platform)][link-download]
 [![Continuous Integration and Delivery][link-github-actions-workflow:status]][link-github-actions-workflow]
 
 

--- a/apps/microfrontend-platform-devtools/src/app/null-if-empty.pipe.ts
+++ b/apps/microfrontend-platform-devtools/src/app/null-if-empty.pipe.ts
@@ -20,14 +20,14 @@ export class NullIfEmptyPipe implements PipeTransform {
     if (value === null || value === undefined) {
       return null;
     }
-    else if ((value instanceof Map || value instanceof Set) && !value.size) {
-      return null;
+    else if (value instanceof Map || value instanceof Set) {
+      return value.size ? value : null;
     }
-    else if ((Array.isArray(value) || typeof value === 'string') && !value.length) {
-      return null;
+    else if (Array.isArray(value) || typeof value === 'string') {
+      return value.length ? value : null;
     }
-    else if (typeof value === 'object' && !Object.keys(value).length) {
-      return null;
+    else if (typeof value === 'object') {
+      return Object.keys(value).length ? value : null;
     }
     return value;
   }

--- a/docs/site/projects-overview.md
+++ b/docs/site/projects-overview.md
@@ -17,11 +17,6 @@ SCION provides fundamental building blocks for implementing a microfrontend arch
 - [**SCION Toolkit**][link-scion-toolkit]\
   SCION Toolkit is a collection of Angular components and utilities designed primarily for use in SCION libraries such as [@scion/workbench][link-scion-workbench] and [@scion/microfrontend-platform][link-scion-microfrontend-platform].
 
-- [<del>**SCION Application Platform**</del> <img src="/docs/logo/angular.svg" alt="Angular-specific" title="Angular-specific">][link-scion-application-platform] **(END-OF-LIFE)**\
-  SCION Workbench Application Platform is an extension of SCION Workbench to integrate content from multiple web applications in a coherent way, thus enabling a micro frontend architecture for allowing different front-end frameworks to co-exist and independent delivery.
-  
-  > The development of the SCION Application Platform was discontinued in favour of the new SCION Microfrontend Platform. SCION Microfrontend Platform is extremely lightweight and does not depend on SCION Workbench and Angular.
-   
 ***
 
 [menu-home]: /README.md
@@ -33,5 +28,3 @@ SCION provides fundamental building blocks for implementing a microfrontend arch
 [link-scion-microfrontend-platform]: /README.md
 [link-scion-workbench]: https://github.com/SchweizerischeBundesbahnen/scion-workbench/blob/master/README.md
 [link-scion-toolkit]: https://github.com/SchweizerischeBundesbahnen/scion-toolkit/blob/master/README.md
-[link-scion-application-platform]: https://github.com/SchweizerischeBundesbahnen/scion-workbench/blob/master/docs/site/application-platform/README.md
-

--- a/docs/site/projects-overview.md
+++ b/docs/site/projects-overview.md
@@ -12,7 +12,7 @@ SCION provides fundamental building blocks for implementing a microfrontend arch
   SCION Microfrontend Platform enables you to successfully implement a framework-agnostic microfrontend architecture by providing you with fundamental APIs for client-side communication, embedding microfrontends, and navigating between the microfrontends. It is a lightweight, web stack agnostic library that has no user-facing components and does not dictate any form of application structure.
   
 - [**SCION Workbench** <img src="/docs/logo/angular.svg" alt="Angular-specific" title="Angular-specific">][link-scion-workbench]\
-  SCION Workbench facilitates the development of Angular web applications that require a complex workbench layout of multiple views and windows. Views are shown within tabs which can be flexibly arranged and dragged around by the user.
+  SCION Workbench enables the creation of Angular web applications that require a flexible layout to arrange content side-by-side or stacked, all personalizable by the user via drag & drop.
    
 - [**SCION Toolkit**][link-scion-toolkit]\
   SCION Toolkit is a collection of Angular components and utilities designed primarily for use in SCION libraries such as [@scion/workbench][link-scion-workbench] and [@scion/microfrontend-platform][link-scion-microfrontend-platform].


### PR DESCRIPTION
For example, if the value is a `Map`with entries, the `typeof object` condition must not apply.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/SchweizerischeBundesbahnen/scion-microfrontend-platform/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added
- [ ] Docs have been added or updated


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance (changes that improve performance)
- [ ] Test (adding missing tests, refactoring tests; no production code change)
- [ ] Chore (other changes like formatting, updating the license, removal of deprecations, etc)
- [ ] Deps (changes related to updating dependencies)
- [ ] CI (changes to our CI configuration files and scripts)
- [ ] Revert (revert of a previous commit)
- [ ] Release (publish a new release)
- [ ] Other... Please describe:

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
