### PR TITLE
feat(platform): provide method to get a specific application

### DIFF
--- a/projects/scion/microfrontend-platform/src/lib/client/manifest-registry/manifest-service.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/client/manifest-registry/manifest-service.spec.ts
@@ -26,6 +26,55 @@ describe('ManifestService', () => {
   beforeEach(async () => await MicrofrontendPlatform.destroy());
   afterEach(async () => await MicrofrontendPlatform.destroy());
 
+  describe('Application', () => {
+    it('should return applications', async () => {
+      await MicrofrontendPlatformHost.start({
+        host: {symbolicName: 'host-app'},
+        applications: [
+          {symbolicName: 'app-1', manifestUrl: new ManifestFixture({name: 'App 1'}).serve()},
+          {symbolicName: 'app-2', manifestUrl: new ManifestFixture({name: 'App 2'}).serve()},
+        ],
+      });
+
+      // Assert applications.
+      expect(Beans.get(ManifestService).applications.map(app => app.symbolicName)).toEqual(jasmine.arrayWithExactContents(['host-app', 'app-1', 'app-2']));
+      // Assert same array reference.
+      expect(Beans.get(ManifestService).applications).toBe(Beans.get(ManifestService).applications);
+    });
+
+    it('should return application if found', async () => {
+      await MicrofrontendPlatformHost.start({
+        host: {symbolicName: 'host-app'},
+        applications: [
+          {symbolicName: 'app-1', manifestUrl: new ManifestFixture({name: 'App 1'}).serve()},
+          {symbolicName: 'app-2', manifestUrl: new ManifestFixture({name: 'App 2'}).serve()},
+        ],
+      });
+
+      expect(Beans.get(ManifestService).getApplication('host-app').symbolicName).toEqual('host-app');
+      expect(Beans.get(ManifestService).getApplication('app-1').symbolicName).toEqual('app-1');
+      expect(Beans.get(ManifestService).getApplication('app-2').symbolicName).toEqual('app-2');
+    });
+
+    it('should return `null` if application is not found', async () => {
+      await MicrofrontendPlatformHost.start({
+        host: {symbolicName: 'host-app'},
+        applications: [],
+      });
+
+      expect(Beans.get(ManifestService).getApplication('app-1', {orElse: null})).toBeNull();
+    });
+
+    it('should error if application is not found', async () => {
+      await MicrofrontendPlatformHost.start({
+        host: {symbolicName: 'host-app'},
+        applications: [],
+      });
+
+      expect(() => Beans.get(ManifestService).getApplication('app-1').symbolicName).toThrowError(/NullApplicationError/);
+    });
+  });
+
   describe('#lookupCapabilities$', () => {
 
     it('should allow looking up own capabilities without declaring an intention (implicit intention)', async () => {

--- a/projects/scion/microfrontend-platform/src/lib/client/manifest-registry/manifest-service.ts
+++ b/projects/scion/microfrontend-platform/src/lib/client/manifest-registry/manifest-service.ts
@@ -53,6 +53,19 @@ export class ManifestService implements Initializer {
   }
 
   /**
+   * Returns the specified application. If not found, by default, throws an error unless setting the `orElseNull` option.
+   */
+  public getApplication(symbolicName: string): Application;
+  public getApplication(symbolicName: string, options: {orElse: null}): Application | null;
+  public getApplication(symbolicName: string, options?: {orElse: null}): Application | null {
+    const application = this._applications.find(application => application.symbolicName === symbolicName);
+    if (!application && !options) {
+      throw Error(`[NullApplicationError] No application found with symbolic name '${symbolicName}'.`);
+    }
+    return application ?? null;
+  }
+
+  /**
    * Allows browsing the catalog of capabilities that match the given filter.
    *
    * <strong>


### PR DESCRIPTION
This commit adds the `ManifestService.getApplication` method to get a specific application. If not found, by default, throws an error unless setting the `orElseNull` option.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/SchweizerischeBundesbahnen/scion-microfrontend-platform/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added
- [ ] Docs have been added or updated


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Fix
- [x] Feature
- [ ] Documentation
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance (changes that improve performance)
- [ ] Test (adding missing tests, refactoring tests; no production code change)
- [ ] Chore (other changes like formatting, updating the license, removal of deprecations, etc)
- [ ] Deps (changes related to updating dependencies)
- [ ] CI (changes to our CI configuration files and scripts)
- [ ] Revert (revert of a previous commit)
- [ ] Release (publish a new release)
- [ ] Other... Please describe:

## Issue

Issue Number: #

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
