### PR TITLE
feat(platform): support capability rejection in interceptor

### DIFF
--- a/apps/microfrontend-platform-testing-app/src/app/manifest/register-capability/register-capability.component.ts
+++ b/apps/microfrontend-platform-testing-app/src/app/manifest/register-capability/register-capability.component.ts
@@ -82,7 +82,7 @@ export default class RegisterCapabilityComponent {
 
     Beans.get(ManifestService).registerCapability(capability)
       .then(id => {
-        this.registerResponse = id;
+        this.registerResponse = id ?? '<null>';
       })
       .catch(error => {
         this.registerError = error;

--- a/docs/adoc/microfrontend-platform-developer-guide/chapters/core-concepts/intention-api/intention-api.adoc
+++ b/docs/adoc/microfrontend-platform-developer-guide/chapters/core-concepts/intention-api/intention-api.adoc
@@ -369,20 +369,30 @@ Similar to <<chapter:intention-api:capability-registration,registering a capabil
 
 [[chapter:intention-api:capability-interception]]
 === Intercepting Capabilities
-The platform allows intercepting capabilities before they are registered, for example, to perform validation checks, add metadata, or change properties.
+The platform allows intercepting capabilities before they are registered, for example, to perform validation checks, add metadata, change properties, or prevent registration based on user permissions.
 
-An interceptor must implement the `intercept` method of the `CapabilityInterceptor` interface. Interceptors are registered in the bean manager of the host application under the symbol `CapabilityInterceptor` as `multi` bean. Multiple interceptors can be registered, forming a chain in which each interceptor is called one by one in registration order.
-
-[source,typescript]
-----
-include::intention-api.snippets.ts[tags=register-capability-interceptor]
-----
-<1> Registers an interceptor to intercept capabilities before they are registered in the platform.
-<2> Starts the platform.
+An interceptor must implement the `intercept` method of the `CapabilityInterceptor` interface.
 
 The following interceptor assigns a stable identifier to each microfrontend capability.
 
 [source,typescript]
 ----
-include::intention-api.snippets.ts[tags=intercept-capability]
+include::intention-api.snippets.ts[tags=intercept-capability:intercept]
 ----
+
+The following interceptor rejects capabilities based on user permissions.
+
+[source,typescript]
+----
+include::intention-api.snippets.ts[tags=intercept-capability:reject]
+----
+
+Interceptors are registered in the bean manager of the host application under the symbol `CapabilityInterceptor` as `multi` bean. Multiple interceptors can be registered, forming a chain in which each interceptor is called one by one in registration order.
+
+[source,typescript]
+----
+include::intention-api.snippets.ts[tags=register-capability-interceptor]
+----
+<1> Registers an interceptor to intercept capabilities. Interceptor must be registered before starting the platform.
+<2> Starts the platform.
+

--- a/docs/adoc/microfrontend-platform-developer-guide/chapters/core-concepts/intention-api/intention-api.snippets.ts
+++ b/docs/adoc/microfrontend-platform-developer-guide/chapters/core-concepts/intention-api/intention-api.snippets.ts
@@ -203,23 +203,39 @@ function hash(capability: Capability): string {
 }
 
 {
-  // tag::intercept-capability[]
+  // tag::intercept-capability:intercept[]
   class MicrofrontendCapabilityInterceptor implements CapabilityInterceptor {
 
     public async intercept(capability: Capability): Promise<Capability> {
       if (capability.type === 'microfrontend') {
         return {
           ...capability,
+          // `hash()` is illustrative and not part of the Microfrontend Platform API
           metadata: {...capability.metadata, id: hash(capability)},
         };
       }
       return capability;
     }
   }
-  // end::intercept-capability[]
+  // end::intercept-capability:intercept[]
+
+  const hasRole = (role: string) => true;
+
+  // tag::intercept-capability:reject[]
+  class UserAuthorizedCapabilityInterceptor implements CapabilityInterceptor {
+
+    public async intercept(capability: Capability): Promise<Capability | null> {
+      const requiredRole = capability.properties?.['role'];
+
+      // `hasRole()` is illustrative and not part of the Microfrontend Platform API
+      return !requiredRole || hasRole(requiredRole) ? capability : null;
+    }
+  }
+  // end::intercept-capability:reject[]
 
   // tag::register-capability-interceptor[]
   Beans.register(CapabilityInterceptor, {useClass: MicrofrontendCapabilityInterceptor}); // <1>
+  Beans.register(CapabilityInterceptor, {useClass: UserAuthorizedCapabilityInterceptor}); // <1>
 
   // Start the platform.
   MicrofrontendPlatformHost.start(...); // <2>

--- a/projects/scion/microfrontend-platform/src/lib/client/manifest-registry/manifest-service.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/client/manifest-registry/manifest-service.spec.ts
@@ -18,6 +18,7 @@ import {ManifestRegistry} from '../../host/manifest-registry/manifest-registry';
 import {ManifestFixture} from '../../testing/manifest-fixture/manifest-fixture';
 import {firstValueFrom} from 'rxjs';
 import {ɵManifestRegistry} from '../../host/manifest-registry/ɵmanifest-registry';
+import {CapabilityInterceptor} from '../../host/manifest-registry/capability-interceptors';
 
 const manifestObjectIdsExtractFn = (manifestObjects: Array<Capability | Intention>): string[] => manifestObjects.map(manifestObject => manifestObject.metadata!.id);
 
@@ -81,15 +82,15 @@ describe('ManifestService', () => {
       await MicrofrontendPlatformHost.start({host: {symbolicName: 'host-app'}, applications: []});
 
       // Register capabilities
-      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app');
+      const exactQualifierCapability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app'))!;
 
-      const qualifier1Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'host-app');
-      const qualifier2Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app');
-      const qualifier3Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
-      const qualifier4Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app');
-      const qualifier5Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null!}, 'host-app');
-      const qualifier6Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app');
-      const qualifier7Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app');
+      const qualifier1Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'host-app'))!;
+      const qualifier2Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app'))!;
+      const qualifier3Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app'))!;
+      const qualifier4Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app'))!;
+      const qualifier5Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null!}, 'host-app'))!;
+      const qualifier6Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app'))!;
+      const qualifier7Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app'))!;
 
       const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
 
@@ -152,11 +153,11 @@ describe('ManifestService', () => {
       Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', '*': '*'}}, 'host-app');
 
       // Register capabilities
-      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}, private: false}, 'app-1');
+      const exactQualifierCapability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}, private: false}, 'app-1'))!;
 
-      const qualifier1Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}, private: false}, 'app-1');
-      const qualifier2Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}, private: false}, 'app-1');
-      const qualifier3Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}, private: false}, 'app-1');
+      const qualifier1Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}, private: false}, 'app-1'))!;
+      const qualifier2Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}, private: false}, 'app-1'))!;
+      const qualifier3Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}, private: false}, 'app-1'))!;
       await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}, private: false}, 'app-1');
       await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null!, private: false}, 'app-1');
       await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined, private: false}, 'app-1');
@@ -223,15 +224,15 @@ describe('ManifestService', () => {
       Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {'*': '*'}}, 'host-app');
 
       // Register capabilities
-      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}, private: false}, 'app-1');
+      const exactQualifierCapability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}, private: false}, 'app-1'))!;
 
-      const qualifier1Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}, private: false}, 'app-1');
-      const qualifier2Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}, private: false}, 'app-1');
-      const qualifier3Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}, private: false}, 'app-1');
-      const qualifier4Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}, private: false}, 'app-1');
-      const qualifier5Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null!, private: false}, 'app-1');
-      const qualifier6Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined, private: false}, 'app-1');
-      const qualifier7Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', private: false}, 'app-1');
+      const qualifier1Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}, private: false}, 'app-1'))!;
+      const qualifier2Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}, private: false}, 'app-1'))!;
+      const qualifier3Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}, private: false}, 'app-1'))!;
+      const qualifier4Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}, private: false}, 'app-1'))!;
+      const qualifier5Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null!, private: false}, 'app-1'))!;
+      const qualifier6Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined, private: false}, 'app-1'))!;
+      const qualifier7Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', private: false}, 'app-1'))!;
 
       const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
 
@@ -294,7 +295,7 @@ describe('ManifestService', () => {
       Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: '*'}}, 'host-app');
 
       // Register capabilities
-      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}, private: false}, 'app-1');
+      const exactQualifierCapability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}, private: false}, 'app-1'))!;
 
       await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}, private: false}, 'app-1');
       await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}, private: false}, 'app-1');
@@ -365,7 +366,7 @@ describe('ManifestService', () => {
       Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app');
 
       // Register capabilities
-      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}, private: false}, 'app-1');
+      const exactQualifierCapability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}, private: false}, 'app-1'))!;
 
       await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}, private: false}, 'app-1');
       await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}, private: false}, 'app-1');
@@ -455,7 +456,7 @@ describe('ManifestService', () => {
       Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {'*': '*'}}, 'host-app');
 
       // Register capability
-      const capabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'app-1');
+      const capabilityId = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'app-1'))!;
 
       const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
 
@@ -487,13 +488,62 @@ describe('ManifestService', () => {
       });
 
       // Register capability
-      const capabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}, private: false}, 'app-1');
+      const capabilityId = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}, private: false}, 'app-1'))!;
 
       const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
 
       // Lookup all capabilities
       Beans.get(ManifestService).lookupCapabilities$({}).subscribe(captor.reset());
       await expectEmissions(captor).toEqual([[capabilityId]]);
+    });
+
+    it('should not register capabilities rejected by an interceptor', async () => {
+      // Register capability interceptor.
+      Beans.register(CapabilityInterceptor, {
+        useValue: new class implements CapabilityInterceptor {
+          public async intercept(capability: Capability): Promise<Capability | null> {
+            if (capability.qualifier?.['reject']) {
+              return null;
+            }
+            return capability;
+          }
+        },
+      });
+
+      // Start host.
+      await MicrofrontendPlatformHost.start({
+        host: {
+          symbolicName: 'host-app',
+          manifest: {
+            name: 'Host App',
+            capabilities: [
+              {type: 'testee-host', qualifier: {reject: true}},
+              {type: 'testee-host', qualifier: {reject: false}},
+            ],
+            intentions: [
+              {type: 'testee-app', qualifier: {'*': '*'}},
+            ],
+          },
+        },
+        applications: [{
+          symbolicName: 'app',
+          manifestUrl: new ManifestFixture({
+            name: 'App 1',
+            capabilities: [
+              {type: 'testee-app', qualifier: {reject: true}, private: false},
+              {type: 'testee-app', qualifier: {reject: false}, private: false},
+            ],
+          }).serve(),
+        }],
+      });
+
+      // Lookup capabilities
+      const captor = new ObserveCaptor();
+      Beans.get(ManifestService).lookupCapabilities$({}).subscribe(captor);
+      await expectEmissions(captor).toEqual([[
+        jasmine.objectContaining({type: 'testee-host', qualifier: {reject: false}} satisfies Partial<Capability>),
+        jasmine.objectContaining({type: 'testee-app', qualifier: {reject: false}} satisfies Partial<Capability>),
+      ]]);
     });
   });
 
@@ -621,15 +671,15 @@ describe('ManifestService', () => {
       });
 
       // Register capabilities
-      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app');
+      const exactQualifierCapability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app'))!;
 
-      const qualifier1Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'host-app');
-      const qualifier2Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app');
-      const qualifier3Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
-      const qualifier4Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app');
-      const qualifier5Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null!}, 'host-app');
-      const qualifier6Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app');
-      const qualifier7Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app');
+      const qualifier1Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'host-app'))!;
+      const qualifier2Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app'))!;
+      const qualifier3Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app'))!;
+      const qualifier4Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app'))!;
+      const qualifier5Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null!}, 'host-app'))!;
+      const qualifier6Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app'))!;
+      const qualifier7Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app'))!;
 
       const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
 
@@ -656,15 +706,15 @@ describe('ManifestService', () => {
       });
 
       // Register capabilities
-      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app');
+      const exactQualifierCapability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app'))!;
 
-      const qualifier1Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'host-app');
-      const qualifier2Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app');
-      const qualifier3Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
-      const qualifier4Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app');
-      const qualifier5Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null!}, 'host-app');
-      const qualifier6Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app');
-      const qualifier7Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app');
+      const qualifier1Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'host-app'))!;
+      const qualifier2Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app'))!;
+      const qualifier3Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app'))!;
+      const qualifier4Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app'))!;
+      const qualifier5Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null!}, 'host-app'))!;
+      const qualifier6Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app'))!;
+      const qualifier7Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app'))!;
 
       const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
 
@@ -691,16 +741,15 @@ describe('ManifestService', () => {
       });
 
       // Register capabilities
-      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app');
+      const exactQualifierCapability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app'))!;
 
-      const qualifier1Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'host-app');
-      const qualifier2Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app');
-      const qualifier3Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
-      const qualifier4Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app');
-      const qualifier5Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null!}, 'host-app');
-      const qualifier6Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app');
-      const qualifier7Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app');
-
+      const qualifier1Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'host-app'))!;
+      const qualifier2Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app'))!;
+      const qualifier3Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app'))!;
+      const qualifier4Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app'))!;
+      const qualifier5Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null!}, 'host-app'))!;
+      const qualifier6Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app'))!;
+      const qualifier7Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app'))!;
       const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
 
       // PRE-CONDITION: Verify all capabilities to be registered
@@ -726,15 +775,15 @@ describe('ManifestService', () => {
       });
 
       // Register capabilities
-      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app');
+      const exactQualifierCapability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app'))!;
 
-      const qualifier1Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'host-app');
-      const qualifier2Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app');
-      const qualifier3Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
-      const qualifier4Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app');
-      const qualifier5Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null!}, 'host-app');
-      const qualifier6Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app');
-      const qualifier7Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app');
+      const qualifier1Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'host-app'))!;
+      const qualifier2Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app'))!;
+      const qualifier3Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app'))!;
+      const qualifier4Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app'))!;
+      const qualifier5Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null!}, 'host-app'))!;
+      const qualifier6Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app'))!;
+      const qualifier7Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app'))!;
 
       const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
 
@@ -761,15 +810,15 @@ describe('ManifestService', () => {
       });
 
       // Register capabilities
-      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app');
+      const exactQualifierCapability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app'))!;
 
-      const qualifier1Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'host-app');
-      const qualifier2Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app');
-      const qualifier3Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
-      const qualifier4Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app');
-      const qualifier5Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null!}, 'host-app');
-      const qualifier6Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app');
-      const qualifier7Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app');
+      const qualifier1Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'host-app'))!;
+      const qualifier2Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app'))!;
+      const qualifier3Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app'))!;
+      const qualifier4Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app'))!;
+      const qualifier5Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null!}, 'host-app'))!;
+      const qualifier6Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app'))!;
+      const qualifier7Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app'))!;
 
       const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
 
@@ -792,15 +841,15 @@ describe('ManifestService', () => {
       });
 
       // Register capabilities
-      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app');
+      const exactQualifierCapability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app'))!;
 
-      const qualifier1Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'host-app');
-      const qualifier2Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app');
-      const qualifier3Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
-      const qualifier4Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app');
-      const qualifier5Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null!}, 'host-app');
-      const qualifier6Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app');
-      const qualifier7Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app');
+      const qualifier1Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'host-app'))!;
+      const qualifier2Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app'))!;
+      const qualifier3Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app'))!;
+      const qualifier4Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app'))!;
+      const qualifier5Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null!}, 'host-app'))!;
+      const qualifier6Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app'))!;
+      const qualifier7Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app'))!;
 
       const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
 
@@ -822,8 +871,8 @@ describe('ManifestService', () => {
         applications: [{symbolicName: 'app-1', manifestUrl: new ManifestFixture({name: 'App 1'}).serve()}],
       });
 
-      const capabilityIdHostApp = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}, private: false}, 'host-app');
-      const capabilityIdApp1 = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}, private: false}, 'app-1');
+      const capabilityIdHostApp = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}, private: false}, 'host-app'))!;
+      const capabilityIdApp1 = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}, private: false}, 'app-1'))!;
 
       // Unregister all capabilities of the host app.
       await Beans.get(ManifestService).unregisterCapabilities();
@@ -1095,9 +1144,9 @@ describe('ManifestService', () => {
       });
 
       // Register private capability for app-1
-      const privateCapabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'testee', private: true}, 'app-1');
+      const privateCapabilityId = (await Beans.get(ManifestRegistry).registerCapability({type: 'testee', private: true}, 'app-1'))!;
       // Register public capability for app-1
-      const publicCapabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'testee', private: false}, 'app-1');
+      const publicCapabilityId = (await Beans.get(ManifestRegistry).registerCapability({type: 'testee', private: false}, 'app-1'))!;
 
       // Expect app-1 to be qualified (app-1 provides capability)
       expect(await firstValueFrom(Beans.get(ManifestService).isApplicationQualified$('app-1', {capabilityId: privateCapabilityId}))).toBeTrue();
@@ -1118,9 +1167,9 @@ describe('ManifestService', () => {
       });
 
       // Register private capability for app-1
-      const privateCapabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'testee', private: true}, 'app-1');
+      const privateCapabilityId = (await Beans.get(ManifestRegistry).registerCapability({type: 'testee', private: true}, 'app-1'))!;
       // Register public capability for app-1
-      const publicCapabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'testee', private: false}, 'app-1');
+      const publicCapabilityId = (await Beans.get(ManifestRegistry).registerCapability({type: 'testee', private: false}, 'app-1'))!;
 
       // Register intention for app-2
       Beans.get(ManifestRegistry).registerIntention({type: 'testee'}, 'app-2');
@@ -1142,7 +1191,7 @@ describe('ManifestService', () => {
       });
 
       // Register private capability for app-1
-      const privateCapabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'testee', private: true}, 'app-1');
+      const privateCapabilityId = (await Beans.get(ManifestRegistry).registerCapability({type: 'testee', private: true}, 'app-1'))!;
 
       // Register intention for app-2
       Beans.get(ManifestRegistry).registerIntention({type: 'testee'}, 'app-2');
@@ -1161,9 +1210,9 @@ describe('ManifestService', () => {
       });
 
       // Register private capability for app-1
-      const privateCapabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'testee', private: true}, 'app-1');
+      const privateCapabilityId = (await Beans.get(ManifestRegistry).registerCapability({type: 'testee', private: true}, 'app-1'))!;
       // Register public capability for app-1
-      const publicCapabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'testee', private: false}, 'app-1');
+      const publicCapabilityId = (await Beans.get(ManifestRegistry).registerCapability({type: 'testee', private: false}, 'app-1'))!;
 
       // Expect app-2 NOT to be qualified (intention check disabled BUT private capability)
       await expect(await firstValueFrom(Beans.get(ManifestService).isApplicationQualified$('app-2', {capabilityId: privateCapabilityId}))).toBeFalse();
@@ -1182,7 +1231,7 @@ describe('ManifestService', () => {
       });
 
       // Register private capability for app-1
-      const privateCapabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'testee', private: true}, 'app-1');
+      const privateCapabilityId = (await Beans.get(ManifestRegistry).registerCapability({type: 'testee', private: true}, 'app-1'))!;
 
       // Expect app-2 to be qualified (scope check and intention check disabled)
       await expect(await firstValueFrom(Beans.get(ManifestService).isApplicationQualified$('app-2', {capabilityId: privateCapabilityId}))).toBeTrue();
@@ -1209,7 +1258,7 @@ describe('ManifestService', () => {
       });
 
       // Register capability for app-1
-      const capabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'testee'}, 'app-1');
+      const capabilityId = (await Beans.get(ManifestRegistry).registerCapability({type: 'testee'}, 'app-1'))!;
 
       // Expect request to error because application does not exist
       await expectAsync(firstValueFrom(Beans.get(ManifestService).isApplicationQualified$('app-2', {capabilityId}))).toBeRejectedWithError(/NullApplicationError/);
@@ -1225,7 +1274,7 @@ describe('ManifestService', () => {
       });
 
       // Register capability for app-1
-      const capabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'testee', private: false}, 'app-1');
+      const capabilityId = (await Beans.get(ManifestRegistry).registerCapability({type: 'testee', private: false}, 'app-1'))!;
 
       const captor = new ObserveCaptor<boolean>();
       Beans.get(ManifestService).isApplicationQualified$('app-2', {capabilityId: capabilityId}).subscribe(captor);

--- a/projects/scion/microfrontend-platform/src/lib/client/manifest-registry/manifest-service.ts
+++ b/projects/scion/microfrontend-platform/src/lib/client/manifest-registry/manifest-service.ts
@@ -107,10 +107,10 @@ export class ManifestService implements Initializer {
   /**
    * Registers given capability. If the capability has public visibility, other applications can browse the capability and interact with it.
    *
-   * @return A Promise that resolves to the identity of the registered capability,
-   *         or that rejects if the registration failed.
+   * @return A Promise that resolves to the identity of the registered capability, if registered, or `null` if rejected by a {@link CapabilityInterceptor}.
+   *         The promise rejects if the registration failed.
    */
-  public registerCapability<T extends Capability>(capability: T): Promise<string> {
+  public registerCapability<T extends Capability>(capability: T): Promise<string | null> {
     const register$ = Beans.get(MessageClient).request$<string>(PlatformTopics.RegisterCapability, capability);
     return lastValueFrom(register$.pipe(mapToBody()));
   }

--- a/projects/scion/microfrontend-platform/src/lib/client/messaging/messaging.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/client/messaging/messaging.spec.ts
@@ -917,7 +917,7 @@ describe('Messaging', () => {
     await MicrofrontendPlatformHost.start({applications: []});
 
     // Register capability
-    const capabilityId = await Beans.get(ManifestService).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}});
+    const capabilityId = (await Beans.get(ManifestService).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}))!;
 
     // Subscribe for intents
     const intentCaptor = new ObserveCaptor(capabilityIdExtractFn);

--- a/projects/scion/microfrontend-platform/src/lib/host/manifest-registry/capability-interceptors.ts
+++ b/projects/scion/microfrontend-platform/src/lib/host/manifest-registry/capability-interceptors.ts
@@ -14,7 +14,8 @@ import {Capability} from '../../platform.model';
  * Allows intercepting capabilities before their registration.
  *
  * Interceptors allow intercepting capabilities before they are registered, for example,
- * to perform validation checks, add metadata, or change properties.
+ * to perform validation checks, add metadata, change properties, or prevent registration
+ * based on user permissions.
  *
  * The following interceptor assigns a stable identifier to each microfrontend capability.
  *
@@ -25,10 +26,25 @@ import {Capability} from '../../platform.model';
  *     if (capability.type === 'microfrontend') {
  *       return {
  *         ...capability,
+ *         // `hash()` is illustrative and not part of the Microfrontend Platform API
  *         metadata: {...capability.metadata, id: hash(capability)},
  *       };
  *     }
  *     return capability;
+ *   }
+ * }
+ * ```
+ *
+ * The following interceptor rejects capabilities based on user permissions.
+ *
+ * ```ts
+ * class UserAuthorizedCapabilityInterceptor implements CapabilityInterceptor {
+ *
+ *   public async intercept(capability: Capability): Promise<Capability | null> {
+ *     const requiredRole = capability.properties?.['role'];
+ *
+ *     // `hasRole()` is illustrative and not part of the Microfrontend Platform API
+ *     return !requiredRole || hasRole(requiredRole) ? capability : null;
  *   }
  * }
  * ```
@@ -39,6 +55,7 @@ import {Capability} from '../../platform.model';
  *
  * ```ts
  * Beans.register(CapabilityInterceptor, {useClass: MicrofrontendCapabilityInterceptor, multi: true});
+ * Beans.register(CapabilityInterceptor, {useClass: UserAuthorizedCapabilityInterceptor, multi: true});
  * ```
  *
  * @category Intention API
@@ -49,6 +66,7 @@ export abstract class CapabilityInterceptor {
    * Intercepts a capability before being registered.
    *
    * @param capability - the capability to be intercepted
+   * @return Promise that resolves to the intercepted capability, or `null` to prevent registration.
    */
-  public abstract intercept(capability: Capability): Promise<Capability>;
+  public abstract intercept(capability: Capability): Promise<Capability | null>;
 }

--- a/projects/scion/microfrontend-platform/src/lib/host/manifest-registry/manifest-registry.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/host/manifest-registry/manifest-registry.spec.ts
@@ -160,7 +160,7 @@ describe('ManifestRegistry', () => {
         });
 
         // Register capability
-        const capabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'app-1');
+        const capabilityId = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'app-1'))!;
 
         expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'app-1').map(capabilityIdExtractFn)).toEqual([capabilityId]);
         expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', mode: 'edit'}}, 'app-1')).toEqual([]);
@@ -186,9 +186,9 @@ describe('ManifestRegistry', () => {
         await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'delete'}, private: true}, 'app-1');
 
         // Register capabilities of app-2 (public, private, implicit-private)
-        const capabilityId1 = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}, private: false}, 'app-2');
-        const capabilityId2 = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'edit'}, private: true}, 'app-2');
-        const capabilityId3 = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'delete'}}, 'app-2');
+        const capabilityId1 = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}, private: false}, 'app-2'))!;
+        const capabilityId2 = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'edit'}, private: true}, 'app-2'))!;
+        const capabilityId3 = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'delete'}}, 'app-2'))!;
 
         expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'app-2').map(capabilityIdExtractFn)).toEqual([capabilityId1]);
         expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', mode: 'edit'}}, 'app-2').map(capabilityIdExtractFn)).toEqual([capabilityId2]);
@@ -210,9 +210,9 @@ describe('ManifestRegistry', () => {
         await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'delete'}, private: false}, 'app-1');
 
         // Register capabilities of app-2 (public, private, implicit-private)
-        const capabilityId1 = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}, private: false}, 'app-2');
-        const capabilityId2 = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'edit'}, private: true}, 'app-2');
-        const capabilityId3 = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'delete'}}, 'app-2');
+        const capabilityId1 = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}, private: false}, 'app-2'))!;
+        const capabilityId2 = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'edit'}, private: true}, 'app-2'))!;
+        const capabilityId3 = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'delete'}}, 'app-2'))!;
 
         expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'app-2').map(capabilityIdExtractFn)).toEqual([capabilityId1]);
         expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', mode: 'edit'}}, 'app-2').map(capabilityIdExtractFn)).toEqual([capabilityId2]);
@@ -232,7 +232,7 @@ describe('ManifestRegistry', () => {
         });
 
         // Register capability of app-1
-        const capabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}, private: false}, 'app-1');
+        const capabilityId = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}, private: false}, 'app-1'))!;
 
         // Register intention of app-2
         Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'app-2');
@@ -250,7 +250,7 @@ describe('ManifestRegistry', () => {
         });
 
         // Register capabilities of app-1
-        const publicCapabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'public'}, private: false}, 'app-1');
+        const publicCapabilityId = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'public'}, private: false}, 'app-1'))!;
         await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'private'}, private: true}, 'app-1');
         await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'implicit-private'}}, 'app-1');
 
@@ -325,13 +325,13 @@ describe('ManifestRegistry', () => {
       });
 
       // Register capability via ManifestServie
-      const capabilityId = await Beans.get(ManifestService).registerCapability({
+      const capabilityId = (await Beans.get(ManifestService).registerCapability({
         type: 'capability',
         params: [
           {name: 'param1', required: true},
           {name: 'param2', required: false},
         ],
-      });
+      }))!;
 
       // Assert registration
       const captor = new ObserveCaptor();
@@ -499,7 +499,7 @@ describe('ManifestRegistry', () => {
     });
   });
 
-  it('should allow intercepting capabilities', async () => {
+  it('should support intercepting capabilities', async () => {
     await MicrofrontendPlatformHost.start({
       host: {symbolicName: 'host-app'},
       applications: [],
@@ -517,12 +517,45 @@ describe('ManifestRegistry', () => {
       },
     });
 
-    // Register a capability.
+    // Register capability.
     await Beans.get(ManifestRegistry).registerCapability({type: 'testee'}, 'host-app');
 
     // Expect the capability to be intercepted before its registration.
     const actual = (await firstValueFrom(Beans.get(ManifestService).lookupCapabilities$({type: 'testee'})))[0]!;
     expect(actual.metadata!.id).toEqual('1');
+  });
+
+  it('should support rejecting capabilities', async () => {
+    await MicrofrontendPlatformHost.start({
+      host: {symbolicName: 'host-app'},
+      applications: [],
+    });
+
+    // Register capability interceptor.
+    Beans.register(CapabilityInterceptor, {
+      useValue: new class implements CapabilityInterceptor {
+        public async intercept(capability: Capability): Promise<Capability | null> {
+          if (capability.qualifier?.['reject']) {
+            return null;
+          }
+          return capability;
+        }
+      },
+    });
+
+    // Register capability 1 (reject).
+    const capabilityId1 = await Beans.get(ManifestRegistry).registerCapability({type: 'testee', qualifier: {reject: true}}, 'host-app');
+    expect(capabilityId1).toBeNull();
+
+    // Register capability 2 (not reject).
+    const capabilityId2 = await Beans.get(ManifestRegistry).registerCapability({type: 'testee', qualifier: {reject: false}}, 'host-app');
+    expect(capabilityId2).not.toBeNull();
+
+    // Expect capability 2 not to be registered.
+    const actual = await firstValueFrom(Beans.get(ManifestService).lookupCapabilities$({type: 'testee'}));
+    expect(actual).toEqual([
+      jasmine.objectContaining({type: 'testee', qualifier: {reject: false}} satisfies Partial<Capability>),
+    ]);
   });
 
   it('should use a unique identifier for capability ID', async () => {

--- a/projects/scion/microfrontend-platform/src/lib/host/manifest-registry/manifest-registry.ts
+++ b/projects/scion/microfrontend-platform/src/lib/host/manifest-registry/manifest-registry.ts
@@ -32,8 +32,10 @@ export abstract class ManifestRegistry {
 
   /**
    * Registers the given capability for the given application.
+   *
+   * @return unique identity of the capability, if registered, or `null` if rejected by a {@link CapabilityInterceptor}.
    */
-  public abstract registerCapability(capability: Capability, appSymbolicName: string): Promise<string>;
+  public abstract registerCapability(capability: Capability, appSymbolicName: string): Promise<string | null>;
 
   /**
    * Registers the given intention for the given application.

--- a/projects/scion/microfrontend-platform/src/lib/host/manifest-registry/ɵmanifest-registry.ts
+++ b/projects/scion/microfrontend-platform/src/lib/host/manifest-registry/ɵmanifest-registry.ts
@@ -118,7 +118,7 @@ export class ɵManifestRegistry implements ManifestRegistry, PreDestroy {
     }).length > 0;
   }
 
-  public async registerCapability(capability: Capability, appSymbolicName: string): Promise<string> {
+  public async registerCapability(capability: Capability, appSymbolicName: string): Promise<string | null> {
     if (!capability) {
       throw Error('[CapabilityRegisterError] Capability must not be null or undefined.');
     }
@@ -145,8 +145,11 @@ export class ɵManifestRegistry implements ManifestRegistry, PreDestroy {
     });
 
     // Register the capability.
-    this._capabilityStore.add(capabilityToRegister);
-    return capabilityToRegister.metadata!.id;
+    if (capabilityToRegister) {
+      this._capabilityStore.add(capabilityToRegister);
+      return capabilityToRegister.metadata!.id;
+    }
+    return null;
   }
 
   public unregisterCapabilities(appSymbolicName: string, filter: ManifestObjectFilter): void {
@@ -183,7 +186,7 @@ export class ɵManifestRegistry implements ManifestRegistry, PreDestroy {
   }
 
   private installCapabilityRegisterRequestHandler(): void {
-    this._subscriptions.add(Beans.get(MessageClient).onMessage<Capability, string>(PlatformTopics.RegisterCapability, (request: TopicMessage<Capability>) => {
+    this._subscriptions.add(Beans.get(MessageClient).onMessage<Capability, string | null>(PlatformTopics.RegisterCapability, (request: TopicMessage<Capability>) => {
       const capability = request.body!;
       const appSymbolicName = request.headers.get(MessageHeaders.AppSymbolicName);
       return this.registerCapability(capability, appSymbolicName);
@@ -335,10 +338,13 @@ function assertCapabilityParamDefinitions(params: ParamDefinition[] | undefined)
 /**
  * Intercepts capability before its registration.
  */
-async function interceptCapability(capability: Capability): Promise<Capability> {
-  const interceptors = Beans.all(CapabilityInterceptor);
-  for (const interceptor of interceptors) {
-    capability = await interceptor.intercept(capability);
+async function interceptCapability(capability: Capability): Promise<Capability | null> {
+  let effectiveCapability: Capability | null = capability;
+  for (const interceptor of Beans.all(CapabilityInterceptor)) {
+    effectiveCapability = await interceptor.intercept(capability);
+    if (effectiveCapability === null) {
+      break; // rejected by the interceptor
+    }
   }
-  return capability;
+  return effectiveCapability;
 }


### PR DESCRIPTION
Returning `null` in a `CapabilityInterceptor` prevents the capability from being registered, e.g, based on user permissions.

Example:
```ts
class UserAuthorizedCapabilityInterceptor implements CapabilityInterceptor {

  public async intercept(capability: Capability): Promise<Capability | null> {
    const requiredRole = capability.properties?.['role'];

    // `hasRole` is illustrative and not part of the Microfrontend Platform API
    return !requiredRole || hasRole(requiredRole) ? capability : null;
  }
}

// Register the interceptor.
Beans.register(CapabilityInterceptor, {useClass: UserAuthorizedCapabilityInterceptor});
```
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/SchweizerischeBundesbahnen/scion-microfrontend-platform/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added
- [x] Docs have been added or updated


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Fix
- [x] Feature
- [ ] Documentation
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance (changes that improve performance)
- [ ] Test (adding missing tests, refactoring tests; no production code change)
- [ ] Chore (other changes like formatting, updating the license, removal of deprecations, etc)
- [ ] Deps (changes related to updating dependencies)
- [ ] CI (changes to our CI configuration files and scripts)
- [ ] Revert (revert of a previous commit)
- [ ] Release (publish a new release)
- [ ] Other... Please describe:

## Issue

Issue Number: #311 

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

**BREAKING CHANGE:** `ManifestService.registerCapability` now returns `null` if registration was prevented by an interceptor