### PR TITLE
feat(platform): support rejecting capability in a capability interceptor

### DIFF
--- a/apps/microfrontend-platform-testing-app/src/app/manifest/register-capability/register-capability.component.ts
+++ b/apps/microfrontend-platform-testing-app/src/app/manifest/register-capability/register-capability.component.ts
@@ -84,7 +84,7 @@ export default class RegisterCapabilityComponent {
 
     Beans.get(ManifestService).registerCapability(capability)
       .then(id => {
-        this.registerResponse = id;
+        this.registerResponse = id ?? '<null>';
       })
       .catch(error => {
         this.registerError = error;

--- a/docs/adoc/microfrontend-platform-developer-guide/chapters/core-concepts/intention-api/intention-api.adoc
+++ b/docs/adoc/microfrontend-platform-developer-guide/chapters/core-concepts/intention-api/intention-api.adoc
@@ -400,6 +400,13 @@ The following interceptor marks capabilities as inactive based on user permissio
 include::intention-api.snippets.ts[tags=intercept-capability:mark-inactive]
 ----
 
+Alternatively, the capability can be rejected. Unlike inactive capabilities, rejected capabilities are not listed in the SCION DevTools.
+
+[source,typescript]
+----
+include::intention-api.snippets.ts[tags=intercept-capability:reject]
+----
+
 An interceptor can add extra capabilities and intentions to the manifest of the intercepted capability. This may be necessary to migrate capabilities.
 
 The following interceptor extracts user information to a new capability.

--- a/docs/adoc/microfrontend-platform-developer-guide/chapters/core-concepts/intention-api/intention-api.snippets.ts
+++ b/docs/adoc/microfrontend-platform-developer-guide/chapters/core-concepts/intention-api/intention-api.snippets.ts
@@ -237,6 +237,19 @@ function hash(capability: Capability): string {
   }
   // end::intercept-capability:mark-inactive[]
 
+  // tag::intercept-capability:reject[]
+  class UserAuthorizedCapabilityInterceptor implements CapabilityInterceptor {
+
+    public async intercept(capability: Capability): Promise<Capability | null> {
+      // Read required role from capability properties.
+      const requiredRole = capability.properties?.['role'];
+
+      // `hasRole()` is illustrative and not part of the Microfrontend Platform API
+      return !requiredRole || hasRole(requiredRole) ? capability : null;
+    }
+  }
+  // end::intercept-capability:reject[]
+
   // tag::intercept-capability:manifest[]
   class UserCapabilityMigrator implements CapabilityInterceptor {
 

--- a/projects/scion/microfrontend-platform/src/lib/client/manifest-registry/manifest-service.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/client/manifest-registry/manifest-service.spec.ts
@@ -18,7 +18,7 @@ import {ManifestRegistry} from '../../host/manifest-registry/manifest-registry';
 import {ManifestFixture} from '../../testing/manifest-fixture/manifest-fixture';
 import {firstValueFrom} from 'rxjs';
 import {ɵManifestRegistry} from '../../host/manifest-registry/ɵmanifest-registry';
-import {CapabilityInterceptor} from '../../host/public_api';
+import {CapabilityInterceptor} from '../../host/manifest-registry/capability-interceptors';
 
 const manifestObjectIdsExtractFn = (manifestObjects: Array<Capability | Intention>): string[] => manifestObjects.map(manifestObject => manifestObject.metadata!.id);
 
@@ -82,15 +82,15 @@ describe('ManifestService', () => {
       await MicrofrontendPlatformHost.start({host: {symbolicName: 'host-app'}, applications: []});
 
       // Register capabilities
-      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app');
+      const exactQualifierCapability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app'))!;
 
-      const qualifier1Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'host-app');
-      const qualifier2Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app');
-      const qualifier3Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
-      const qualifier4Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app');
-      const qualifier5Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null!}, 'host-app');
-      const qualifier6Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app');
-      const qualifier7Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app');
+      const qualifier1Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'host-app'))!;
+      const qualifier2Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app'))!;
+      const qualifier3Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app'))!;
+      const qualifier4Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app'))!;
+      const qualifier5Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null!}, 'host-app'))!;
+      const qualifier6Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app'))!;
+      const qualifier7Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app'))!;
 
       const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
 
@@ -153,11 +153,11 @@ describe('ManifestService', () => {
       Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', '*': '*'}}, 'host-app');
 
       // Register capabilities
-      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}, private: false}, 'app-1');
+      const exactQualifierCapability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}, private: false}, 'app-1'))!;
 
-      const qualifier1Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}, private: false}, 'app-1');
-      const qualifier2Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}, private: false}, 'app-1');
-      const qualifier3Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}, private: false}, 'app-1');
+      const qualifier1Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}, private: false}, 'app-1'))!;
+      const qualifier2Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}, private: false}, 'app-1'))!;
+      const qualifier3Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}, private: false}, 'app-1'))!;
       await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}, private: false}, 'app-1');
       await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null!, private: false}, 'app-1');
       await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined, private: false}, 'app-1');
@@ -224,15 +224,15 @@ describe('ManifestService', () => {
       Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {'*': '*'}}, 'host-app');
 
       // Register capabilities
-      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}, private: false}, 'app-1');
+      const exactQualifierCapability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}, private: false}, 'app-1'))!;
 
-      const qualifier1Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}, private: false}, 'app-1');
-      const qualifier2Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}, private: false}, 'app-1');
-      const qualifier3Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}, private: false}, 'app-1');
-      const qualifier4Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}, private: false}, 'app-1');
-      const qualifier5Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null!, private: false}, 'app-1');
-      const qualifier6Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined, private: false}, 'app-1');
-      const qualifier7Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', private: false}, 'app-1');
+      const qualifier1Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}, private: false}, 'app-1'))!;
+      const qualifier2Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}, private: false}, 'app-1'))!;
+      const qualifier3Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}, private: false}, 'app-1'))!;
+      const qualifier4Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}, private: false}, 'app-1'))!;
+      const qualifier5Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null!, private: false}, 'app-1'))!;
+      const qualifier6Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined, private: false}, 'app-1'))!;
+      const qualifier7Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', private: false}, 'app-1'))!;
 
       const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
 
@@ -295,7 +295,7 @@ describe('ManifestService', () => {
       Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: '*'}}, 'host-app');
 
       // Register capabilities
-      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}, private: false}, 'app-1');
+      const exactQualifierCapability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}, private: false}, 'app-1'))!;
 
       await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}, private: false}, 'app-1');
       await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}, private: false}, 'app-1');
@@ -366,7 +366,7 @@ describe('ManifestService', () => {
       Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app');
 
       // Register capabilities
-      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}, private: false}, 'app-1');
+      const exactQualifierCapability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}, private: false}, 'app-1'))!;
 
       await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}, private: false}, 'app-1');
       await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}, private: false}, 'app-1');
@@ -456,7 +456,7 @@ describe('ManifestService', () => {
       Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {'*': '*'}}, 'host-app');
 
       // Register capability
-      const capabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'app-1');
+      const capabilityId = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'app-1'))!;
 
       const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
 
@@ -488,7 +488,7 @@ describe('ManifestService', () => {
       });
 
       // Register capability
-      const capabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}, private: false}, 'app-1');
+      const capabilityId = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}, private: false}, 'app-1'))!;
 
       const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
 
@@ -659,6 +659,55 @@ describe('ManifestService', () => {
         ]),
       ]);
     });
+
+    it('should not look up capabilities rejected by an interceptor', async () => {
+      // Register capability interceptor.
+      Beans.register(CapabilityInterceptor, {
+        useValue: new class implements CapabilityInterceptor {
+          public async intercept(capability: Capability): Promise<Capability | null> {
+            if (capability.qualifier?.['reject']) {
+              return null;
+            }
+            return capability;
+          }
+        },
+      });
+
+      // Start host.
+      await MicrofrontendPlatformHost.start({
+        host: {
+          symbolicName: 'host-app',
+          manifest: {
+            name: 'Host App',
+            capabilities: [
+              {type: 'testee-host', qualifier: {reject: true}},
+              {type: 'testee-host', qualifier: {reject: false}},
+            ],
+            intentions: [
+              {type: 'testee-app', qualifier: {'*': '*'}},
+            ],
+          },
+        },
+        applications: [{
+          symbolicName: 'app',
+          manifestUrl: new ManifestFixture({
+            name: 'App 1',
+            capabilities: [
+              {type: 'testee-app', qualifier: {reject: true}, private: false},
+              {type: 'testee-app', qualifier: {reject: false}, private: false},
+            ],
+          }).serve(),
+        }],
+      });
+
+      // Lookup capabilities
+      const captor = new ObserveCaptor();
+      Beans.get(ManifestService).lookupCapabilities$({}).subscribe(captor);
+      await expectEmissions(captor).toEqual([[
+        jasmine.objectContaining({type: 'testee-host', qualifier: {reject: false}} satisfies Partial<Capability>),
+        jasmine.objectContaining({type: 'testee-app', qualifier: {reject: false}} satisfies Partial<Capability>),
+      ]]);
+    });
   });
 
   describe('#lookupIntentions$', () => {
@@ -785,15 +834,15 @@ describe('ManifestService', () => {
       });
 
       // Register capabilities
-      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app');
+      const exactQualifierCapability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app'))!;
 
-      const qualifier1Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'host-app');
-      const qualifier2Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app');
-      const qualifier3Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
-      const qualifier4Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app');
-      const qualifier5Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null!}, 'host-app');
-      const qualifier6Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app');
-      const qualifier7Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app');
+      const qualifier1Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'host-app'))!;
+      const qualifier2Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app'))!;
+      const qualifier3Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app'))!;
+      const qualifier4Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app'))!;
+      const qualifier5Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null!}, 'host-app'))!;
+      const qualifier6Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app'))!;
+      const qualifier7Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app'))!;
 
       const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
 
@@ -820,15 +869,15 @@ describe('ManifestService', () => {
       });
 
       // Register capabilities
-      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app');
+      const exactQualifierCapability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app'))!;
 
-      const qualifier1Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'host-app');
-      const qualifier2Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app');
-      const qualifier3Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
-      const qualifier4Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app');
-      const qualifier5Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null!}, 'host-app');
-      const qualifier6Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app');
-      const qualifier7Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app');
+      const qualifier1Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'host-app'))!;
+      const qualifier2Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app'))!;
+      const qualifier3Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app'))!;
+      const qualifier4Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app'))!;
+      const qualifier5Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null!}, 'host-app'))!;
+      const qualifier6Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app'))!;
+      const qualifier7Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app'))!;
 
       const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
 
@@ -855,16 +904,15 @@ describe('ManifestService', () => {
       });
 
       // Register capabilities
-      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app');
+      const exactQualifierCapability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app'))!;
 
-      const qualifier1Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'host-app');
-      const qualifier2Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app');
-      const qualifier3Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
-      const qualifier4Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app');
-      const qualifier5Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null!}, 'host-app');
-      const qualifier6Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app');
-      const qualifier7Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app');
-
+      const qualifier1Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'host-app'))!;
+      const qualifier2Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app'))!;
+      const qualifier3Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app'))!;
+      const qualifier4Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app'))!;
+      const qualifier5Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null!}, 'host-app'))!;
+      const qualifier6Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app'))!;
+      const qualifier7Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app'))!;
       const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
 
       // PRE-CONDITION: Verify all capabilities to be registered
@@ -890,15 +938,15 @@ describe('ManifestService', () => {
       });
 
       // Register capabilities
-      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app');
+      const exactQualifierCapability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app'))!;
 
-      const qualifier1Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'host-app');
-      const qualifier2Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app');
-      const qualifier3Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
-      const qualifier4Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app');
-      const qualifier5Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null!}, 'host-app');
-      const qualifier6Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app');
-      const qualifier7Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app');
+      const qualifier1Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'host-app'))!;
+      const qualifier2Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app'))!;
+      const qualifier3Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app'))!;
+      const qualifier4Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app'))!;
+      const qualifier5Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null!}, 'host-app'))!;
+      const qualifier6Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app'))!;
+      const qualifier7Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app'))!;
 
       const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
 
@@ -925,15 +973,15 @@ describe('ManifestService', () => {
       });
 
       // Register capabilities
-      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app');
+      const exactQualifierCapability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app'))!;
 
-      const qualifier1Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'host-app');
-      const qualifier2Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app');
-      const qualifier3Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
-      const qualifier4Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app');
-      const qualifier5Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null!}, 'host-app');
-      const qualifier6Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app');
-      const qualifier7Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app');
+      const qualifier1Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'host-app'))!;
+      const qualifier2Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app'))!;
+      const qualifier3Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app'))!;
+      const qualifier4Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app'))!;
+      const qualifier5Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null!}, 'host-app'))!;
+      const qualifier6Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app'))!;
+      const qualifier7Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app'))!;
 
       const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
 
@@ -956,15 +1004,15 @@ describe('ManifestService', () => {
       });
 
       // Register capabilities
-      const exactQualifierCapability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app');
+      const exactQualifierCapability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'host-app'))!;
 
-      const qualifier1Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'host-app');
-      const qualifier2Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app');
-      const qualifier3Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app');
-      const qualifier4Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app');
-      const qualifier5Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null!}, 'host-app');
-      const qualifier6Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app');
-      const qualifier7Capability = await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app');
+      const qualifier1Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}}, 'host-app'))!;
+      const qualifier2Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new', other: 'property'}}, 'host-app'))!;
+      const qualifier3Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', other: 'property'}}, 'host-app'))!;
+      const qualifier4Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {}}, 'host-app'))!;
+      const qualifier5Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: null!}, 'host-app'))!;
+      const qualifier6Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: undefined}, 'host-app'))!;
+      const qualifier7Capability = (await Beans.get(ManifestRegistry).registerCapability({type: 'view'}, 'host-app'))!;
 
       const captor = new ObserveCaptor(manifestObjectIdsExtractFn);
 
@@ -986,8 +1034,8 @@ describe('ManifestService', () => {
         applications: [{symbolicName: 'app-1', manifestUrl: new ManifestFixture({name: 'App 1'}).serve()}],
       });
 
-      const capabilityIdHostApp = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}, private: false}, 'host-app');
-      const capabilityIdApp1 = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}, private: false}, 'app-1');
+      const capabilityIdHostApp = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}, private: false}, 'host-app'))!;
+      const capabilityIdApp1 = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person'}, private: false}, 'app-1'))!;
 
       // Unregister all capabilities of the host app.
       await Beans.get(ManifestService).unregisterCapabilities();
@@ -1259,9 +1307,9 @@ describe('ManifestService', () => {
       });
 
       // Register private capability for app-1
-      const privateCapabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'testee', private: true}, 'app-1');
+      const privateCapabilityId = (await Beans.get(ManifestRegistry).registerCapability({type: 'testee', private: true}, 'app-1'))!;
       // Register public capability for app-1
-      const publicCapabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'testee', private: false}, 'app-1');
+      const publicCapabilityId = (await Beans.get(ManifestRegistry).registerCapability({type: 'testee', private: false}, 'app-1'))!;
 
       // Expect app-1 to be qualified (app-1 provides capability)
       expect(await firstValueFrom(Beans.get(ManifestService).isApplicationQualified$('app-1', {capabilityId: privateCapabilityId}))).toBeTrue();
@@ -1282,9 +1330,9 @@ describe('ManifestService', () => {
       });
 
       // Register private capability for app-1
-      const privateCapabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'testee', private: true}, 'app-1');
+      const privateCapabilityId = (await Beans.get(ManifestRegistry).registerCapability({type: 'testee', private: true}, 'app-1'))!;
       // Register public capability for app-1
-      const publicCapabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'testee', private: false}, 'app-1');
+      const publicCapabilityId = (await Beans.get(ManifestRegistry).registerCapability({type: 'testee', private: false}, 'app-1'))!;
 
       // Register intention for app-2
       Beans.get(ManifestRegistry).registerIntention({type: 'testee'}, 'app-2');
@@ -1306,7 +1354,7 @@ describe('ManifestService', () => {
       });
 
       // Register private capability for app-1
-      const privateCapabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'testee', private: true}, 'app-1');
+      const privateCapabilityId = (await Beans.get(ManifestRegistry).registerCapability({type: 'testee', private: true}, 'app-1'))!;
 
       // Register intention for app-2
       Beans.get(ManifestRegistry).registerIntention({type: 'testee'}, 'app-2');
@@ -1325,9 +1373,9 @@ describe('ManifestService', () => {
       });
 
       // Register private capability for app-1
-      const privateCapabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'testee', private: true}, 'app-1');
+      const privateCapabilityId = (await Beans.get(ManifestRegistry).registerCapability({type: 'testee', private: true}, 'app-1'))!;
       // Register public capability for app-1
-      const publicCapabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'testee', private: false}, 'app-1');
+      const publicCapabilityId = (await Beans.get(ManifestRegistry).registerCapability({type: 'testee', private: false}, 'app-1'))!;
 
       // Expect app-2 NOT to be qualified (intention check disabled BUT private capability)
       await expect(await firstValueFrom(Beans.get(ManifestService).isApplicationQualified$('app-2', {capabilityId: privateCapabilityId}))).toBeFalse();
@@ -1346,7 +1394,7 @@ describe('ManifestService', () => {
       });
 
       // Register private capability for app-1
-      const privateCapabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'testee', private: true}, 'app-1');
+      const privateCapabilityId = (await Beans.get(ManifestRegistry).registerCapability({type: 'testee', private: true}, 'app-1'))!;
 
       // Expect app-2 to be qualified (scope check and intention check disabled)
       await expect(await firstValueFrom(Beans.get(ManifestService).isApplicationQualified$('app-2', {capabilityId: privateCapabilityId}))).toBeTrue();
@@ -1626,7 +1674,7 @@ describe('ManifestService', () => {
       });
 
       // Register capability for app-1
-      const capabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'testee'}, 'app-1');
+      const capabilityId = (await Beans.get(ManifestRegistry).registerCapability({type: 'testee'}, 'app-1'))!;
 
       // Expect request to error because application does not exist
       await expectAsync(firstValueFrom(Beans.get(ManifestService).isApplicationQualified$('app-2', {capabilityId}))).toBeRejectedWithError(/NullApplicationError/);
@@ -1642,7 +1690,7 @@ describe('ManifestService', () => {
       });
 
       // Register capability for app-1
-      const capabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'testee', private: false}, 'app-1');
+      const capabilityId = (await Beans.get(ManifestRegistry).registerCapability({type: 'testee', private: false}, 'app-1'))!;
 
       const captor = new ObserveCaptor<boolean>();
       Beans.get(ManifestService).isApplicationQualified$('app-2', {capabilityId: capabilityId}).subscribe(captor);

--- a/projects/scion/microfrontend-platform/src/lib/client/manifest-registry/manifest-service.ts
+++ b/projects/scion/microfrontend-platform/src/lib/client/manifest-registry/manifest-service.ts
@@ -107,10 +107,10 @@ export class ManifestService implements Initializer {
   /**
    * Registers given capability. If the capability has public visibility, other applications can browse the capability and interact with it.
    *
-   * @return A Promise that resolves to the identity of the registered capability,
-   *         or that rejects if the registration failed.
+   * @return A Promise that resolves to the identity of the registered capability, if registered, or `null` if rejected by a {@link CapabilityInterceptor}.
+   *         The promise rejects if the registration failed.
    */
-  public registerCapability<T extends Capability>(capability: T): Promise<string> {
+  public registerCapability<T extends Capability>(capability: T): Promise<string | null> {
     const register$ = Beans.get(MessageClient).request$<string>(PlatformTopics.RegisterCapability, capability);
     return lastValueFrom(register$.pipe(mapToBody()));
   }

--- a/projects/scion/microfrontend-platform/src/lib/client/messaging/messaging.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/client/messaging/messaging.spec.ts
@@ -917,7 +917,7 @@ describe('Messaging', () => {
     await MicrofrontendPlatformHost.start({applications: []});
 
     // Register capability
-    const capabilityId = await Beans.get(ManifestService).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}});
+    const capabilityId = (await Beans.get(ManifestService).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}))!;
 
     // Subscribe for intents
     const intentCaptor = new ObserveCaptor(capabilityIdExtractFn);

--- a/projects/scion/microfrontend-platform/src/lib/host/manifest-registry/capability-interceptors.ts
+++ b/projects/scion/microfrontend-platform/src/lib/host/manifest-registry/capability-interceptors.ts
@@ -52,6 +52,20 @@ import {Capability, Intention} from '../../platform.model';
  *   }
  * }
  * ```
+ * Alternatively, the capability can be rejected. Unlike inactive capabilities, rejected capabilities are not listed in the SCION DevTools.
+ *
+ * ```ts
+ * class UserAuthorizedCapabilityInterceptor implements CapabilityInterceptor {
+ *
+ *   public async intercept(capability: Capability): Promise<Capability | null> {
+ *     // Read required role from capability properties.
+ *     const requiredRole = capability.properties?.['role'];
+ *
+ *     // `hasRole()` is illustrative and not part of the Microfrontend Platform API.
+ *     return !requiredRole || hasRole(requiredRole) ? capability : null;
+ *   }
+ * }
+ * ```
  *
  * The following interceptor extracts user information to a new capability.
  *
@@ -96,8 +110,9 @@ export abstract class CapabilityInterceptor {
    *
    * @param capability - Capability to be intercepted.
    * @param manifest - Manifest of the application that provides the intercepted capability, allowing for the registration of extra capabilities and intentions.
+   * @return Promise that resolves to the intercepted capability, or `null` to prevent registration.
    */
-  public abstract intercept(capability: Capability, manifest: CapabilityInterceptor.Manifest): Promise<Capability>;
+  public abstract intercept(capability: Capability, manifest: CapabilityInterceptor.Manifest): Promise<Capability | null>;
 }
 
 /**

--- a/projects/scion/microfrontend-platform/src/lib/host/manifest-registry/manifest-registry.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/host/manifest-registry/manifest-registry.spec.ts
@@ -274,7 +274,7 @@ describe('ManifestRegistry', () => {
         });
 
         // Register capability
-        const capabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'app-1');
+        const capabilityId = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'app-1'))!;
 
         expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'app-1').map(capabilityIdExtractFn)).toEqual([capabilityId]);
         expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', mode: 'edit'}}, 'app-1')).toEqual([]);
@@ -300,9 +300,9 @@ describe('ManifestRegistry', () => {
         await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'delete'}, private: true}, 'app-1');
 
         // Register capabilities of app-2 (public, private, implicit-private)
-        const capabilityId1 = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}, private: false}, 'app-2');
-        const capabilityId2 = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'edit'}, private: true}, 'app-2');
-        const capabilityId3 = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'delete'}}, 'app-2');
+        const capabilityId1 = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}, private: false}, 'app-2'))!;
+        const capabilityId2 = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'edit'}, private: true}, 'app-2'))!;
+        const capabilityId3 = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'delete'}}, 'app-2'))!;
 
         expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'app-2').map(capabilityIdExtractFn)).toEqual([capabilityId1]);
         expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', mode: 'edit'}}, 'app-2').map(capabilityIdExtractFn)).toEqual([capabilityId2]);
@@ -324,9 +324,9 @@ describe('ManifestRegistry', () => {
         await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'delete'}, private: false}, 'app-1');
 
         // Register capabilities of app-2 (public, private, implicit-private)
-        const capabilityId1 = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}, private: false}, 'app-2');
-        const capabilityId2 = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'edit'}, private: true}, 'app-2');
-        const capabilityId3 = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'delete'}}, 'app-2');
+        const capabilityId1 = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}, private: false}, 'app-2'))!;
+        const capabilityId2 = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'edit'}, private: true}, 'app-2'))!;
+        const capabilityId3 = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'delete'}}, 'app-2'))!;
 
         expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'app-2').map(capabilityIdExtractFn)).toEqual([capabilityId1]);
         expect(Beans.get(ManifestRegistry).resolveCapabilitiesByIntent({type: 'view', qualifier: {entity: 'person', mode: 'edit'}}, 'app-2').map(capabilityIdExtractFn)).toEqual([capabilityId2]);
@@ -346,7 +346,7 @@ describe('ManifestRegistry', () => {
         });
 
         // Register capability of app-1
-        const capabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}, private: false}, 'app-1');
+        const capabilityId = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'new'}, private: false}, 'app-1'))!;
 
         // Register intention of app-2
         Beans.get(ManifestRegistry).registerIntention({type: 'view', qualifier: {entity: 'person', mode: 'new'}}, 'app-2');
@@ -364,7 +364,7 @@ describe('ManifestRegistry', () => {
         });
 
         // Register capabilities of app-1
-        const publicCapabilityId = await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'public'}, private: false}, 'app-1');
+        const publicCapabilityId = (await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'public'}, private: false}, 'app-1'))!;
         await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'private'}, private: true}, 'app-1');
         await Beans.get(ManifestRegistry).registerCapability({type: 'view', qualifier: {entity: 'person', mode: 'implicit-private'}}, 'app-1');
 
@@ -439,13 +439,13 @@ describe('ManifestRegistry', () => {
       });
 
       // Register capability via ManifestServie
-      const capabilityId = await Beans.get(ManifestService).registerCapability({
+      const capabilityId = (await Beans.get(ManifestService).registerCapability({
         type: 'capability',
         params: [
           {name: 'param1', required: true},
           {name: 'param2', required: false},
         ],
-      });
+      }))!;
 
       // Assert registration
       const captor = new ObserveCaptor();
@@ -632,12 +632,92 @@ describe('ManifestRegistry', () => {
       multi: true,
     });
 
-    // Register a capability.
+    // Register capability.
     await Beans.get(ManifestRegistry).registerCapability({type: 'testee'}, 'host-app');
 
     // Expect the capability to be intercepted before its registration.
     const actual = (await firstValueFrom(Beans.get(ManifestService).lookupCapabilities$({type: 'testee'})))[0]!;
     expect(actual.metadata!.id).toEqual('1');
+  });
+
+  it('should call interceptors in registration order', async () => {
+    await MicrofrontendPlatformHost.start({
+      host: {symbolicName: 'host-app'},
+      applications: [],
+    });
+
+    // Register capability interceptor.
+    Beans.register(CapabilityInterceptor, {
+      useValue: new class implements CapabilityInterceptor {
+        public async intercept(capability: Capability): Promise<Capability> {
+          return {
+            ...capability,
+            properties: {
+              ['interceptors']: ['interceptor-1'],
+            },
+          };
+        }
+      }(),
+      multi: true,
+    });
+
+    // Register capability interceptor.
+    Beans.register(CapabilityInterceptor, {
+      useValue: new class implements CapabilityInterceptor {
+        public async intercept(capability: Capability): Promise<Capability> {
+          return {
+            ...capability,
+            properties: {
+              ['interceptors']: [...capability.properties!['interceptors'] as string[], 'interceptor-2'],
+            },
+          };
+        }
+      }(),
+      multi: true,
+    });
+
+    // Register capability.
+    await Beans.get(ManifestRegistry).registerCapability({type: 'testee'}, 'host-app');
+
+    // Expect the interceptors to be called in registration order.
+    const captor = new ObserveCaptor();
+    Beans.get(ManifestService).lookupCapabilities$({type: 'testee'}).subscribe(captor);
+    await expectEmissions(captor).toEqual([
+      [jasmine.objectContaining({type: 'testee', properties: {interceptors: ['interceptor-1', 'interceptor-2']}} satisfies Partial<Capability>)],
+    ]);
+  });
+
+  it('should support rejecting capabilities', async () => {
+    await MicrofrontendPlatformHost.start({
+      host: {symbolicName: 'host-app'},
+      applications: [],
+    });
+
+    // Register capability interceptor.
+    Beans.register(CapabilityInterceptor, {
+      useValue: new class implements CapabilityInterceptor {
+        public async intercept(capability: Capability): Promise<Capability | null> {
+          if (capability.qualifier?.['reject']) {
+            return null;
+          }
+          return capability;
+        }
+      },
+    });
+
+    // Register capability 1 (reject).
+    const capabilityId1 = await Beans.get(ManifestRegistry).registerCapability({type: 'testee', qualifier: {reject: true}}, 'host-app');
+    expect(capabilityId1).toBeNull();
+
+    // Register capability 2 (not reject).
+    const capabilityId2 = await Beans.get(ManifestRegistry).registerCapability({type: 'testee', qualifier: {reject: false}}, 'host-app');
+    expect(capabilityId2).not.toBeNull();
+
+    // Expect capability 2 not to be registered.
+    const actual = await firstValueFrom(Beans.get(ManifestService).lookupCapabilities$({type: 'testee'}));
+    expect(actual).toEqual([
+      jasmine.objectContaining({type: 'testee', qualifier: {reject: false}} satisfies Partial<Capability>),
+    ]);
   });
 
   it('should support registering capabilities when intercepting capability', async () => {

--- a/projects/scion/microfrontend-platform/src/lib/host/manifest-registry/manifest-registry.ts
+++ b/projects/scion/microfrontend-platform/src/lib/host/manifest-registry/manifest-registry.ts
@@ -32,8 +32,10 @@ export abstract class ManifestRegistry {
 
   /**
    * Registers the given capability for the given application.
+   *
+   * @return unique identity of the capability, if registered, or `null` if rejected by a {@link CapabilityInterceptor}.
    */
-  public abstract registerCapability(capability: Capability, appSymbolicName: string): Promise<string>;
+  public abstract registerCapability(capability: Capability, appSymbolicName: string): Promise<string | null>;
 
   /**
    * Registers the given intention for the given application.

--- a/projects/scion/microfrontend-platform/src/lib/host/manifest-registry/ɵmanifest-registry.ts
+++ b/projects/scion/microfrontend-platform/src/lib/host/manifest-registry/ɵmanifest-registry.ts
@@ -140,7 +140,7 @@ export class ɵManifestRegistry implements ManifestRegistry, PreDestroy {
     }).length > 0;
   }
 
-  public async registerCapability(capability: Capability, appSymbolicName: string): Promise<string> {
+  public async registerCapability(capability: Capability, appSymbolicName: string): Promise<string | null> {
     if (!capability) {
       throw Error('[CapabilityRegisterError] Capability must not be null or undefined.');
     }
@@ -168,8 +168,11 @@ export class ɵManifestRegistry implements ManifestRegistry, PreDestroy {
     });
 
     // Register the capability.
-    this._capabilityStore.add(capabilityToRegister);
-    return capabilityToRegister.metadata!.id;
+    if (capabilityToRegister) {
+      this._capabilityStore.add(capabilityToRegister);
+      return capabilityToRegister.metadata!.id;
+    }
+    return null;
   }
 
   public unregisterCapabilities(appSymbolicName: string, filter: ManifestObjectFilter): void {
@@ -206,7 +209,7 @@ export class ɵManifestRegistry implements ManifestRegistry, PreDestroy {
   }
 
   private installCapabilityRegisterRequestHandler(): void {
-    this._subscriptions.add(Beans.get(MessageClient).onMessage<Capability, string>(PlatformTopics.RegisterCapability, (request: TopicMessage<Capability>) => {
+    this._subscriptions.add(Beans.get(MessageClient).onMessage<Capability, string | null>(PlatformTopics.RegisterCapability, (request: TopicMessage<Capability>) => {
       const capability = request.body!;
       const appSymbolicName = request.headers.get(MessageHeaders.AppSymbolicName);
       return this.registerCapability(capability, appSymbolicName);
@@ -358,12 +361,11 @@ function assertCapabilityParamDefinitions(params: ParamDefinition[] | undefined)
 /**
  * Intercepts capability before its registration.
  */
-async function interceptCapability(capability: Capability): Promise<Capability> {
+async function interceptCapability(capability: Capability): Promise<Capability | null> {
   const interceptors = Beans.all(CapabilityInterceptor);
-
   const appSymbolicName = capability.metadata!.appSymbolicName;
   const manifest = new class implements CapabilityInterceptor.Manifest {
-    public addCapability<T extends Capability>(capability: T): Promise<string> {
+    public addCapability<T extends Capability>(capability: T): Promise<string | null> {
       return Beans.get(ManifestRegistry).registerCapability(capability, appSymbolicName);
     }
 
@@ -372,8 +374,12 @@ async function interceptCapability(capability: Capability): Promise<Capability> 
     }
   }();
 
+  let interceptedCapability: Capability | null = capability;
   for (const interceptor of interceptors) {
-    capability = await interceptor.intercept(capability, manifest);
+    interceptedCapability = await interceptor.intercept(interceptedCapability!, manifest);
+    if (interceptedCapability === null) {
+      break; // rejected by the interceptor
+    }
   }
-  return capability;
+  return interceptedCapability;
 }


### PR DESCRIPTION
Returning `null` in a `CapabilityInterceptor` prevents the capability from being registered, e.g, based on user permissions. Unlike inactive capabilities, rejected capabilities are not listed in the SCION DevTools.

Example:
```ts
class UserAuthorizedCapabilityInterceptor implements CapabilityInterceptor {

  public async intercept(capability: Capability): Promise<Capability | null> {
    // Read required role from capability properties.
    const requiredRole = capability.properties?.['role'];

    // `hasRole` is illustrative and not part of the Microfrontend Platform API.
    return !requiredRole || hasRole(requiredRole) ? capability : null;
  }
}

// Register the interceptor.
Beans.register(CapabilityInterceptor, {useClass: UserAuthorizedCapabilityInterceptor, multi: true});
```

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/SchweizerischeBundesbahnen/scion-microfrontend-platform/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added
- [x] Docs have been added or updated


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Fix
- [x] Feature
- [ ] Documentation
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance (changes that improve performance)
- [ ] Test (adding missing tests, refactoring tests; no production code change)
- [ ] Chore (other changes like formatting, updating the license, removal of deprecations, etc)
- [ ] Deps (changes related to updating dependencies)
- [ ] CI (changes to our CI configuration files and scripts)
- [ ] Revert (revert of a previous commit)
- [ ] Release (publish a new release)
- [ ] Other... Please describe:

## Issue

Issue Number: #311

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

**BREAKING CHANGE:** `ManifestService.registerCapability` now returns `null` if an interceptor prevented registration