### PR TITLE
feat(platform): stop platform on `pagehide` event synchronously

### DIFF
--- a/apps/microfrontend-platform-testing-app/src/app/app.component.ts
+++ b/apps/microfrontend-platform-testing-app/src/app/app.component.ts
@@ -7,8 +7,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {afterEveryRender, ChangeDetectionStrategy, Component, DestroyRef, ElementRef, inject, NgZone} from '@angular/core';
-import {ContextService, MicrofrontendPlatform, OUTLET_CONTEXT, OutletContext} from '@scion/microfrontend-platform';
+import {afterEveryRender, ChangeDetectionStrategy, Component, ElementRef, inject, NgZone} from '@angular/core';
+import {ContextService, OUTLET_CONTEXT, OutletContext} from '@scion/microfrontend-platform';
 import {Beans} from '@scion/toolkit/bean-manager';
 import {fromEvent, merge, withLatestFrom} from 'rxjs';
 import {subscribeIn} from '@scion/toolkit/operators';
@@ -28,7 +28,6 @@ import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 export class AppComponent {
 
   private readonly _zone = inject(NgZone);
-  private readonly _destroyRef = inject(DestroyRef);
   private readonly _host = inject(ElementRef).nativeElement as HTMLElement;
   private readonly _outletContext = Beans.get(ContextService).lookup<OutletContext>(OUTLET_CONTEXT);
 
@@ -38,8 +37,6 @@ export class AppComponent {
     afterEveryRender(() => {
       this._host.setAttribute('data-last-render', Date.now().toString());
     });
-
-    this._destroyRef.onDestroy(() => void MicrofrontendPlatform.destroy()); // Platform is started in {@link PlatformInitializer}
   }
 
   // TODO [Angular 23] Remove if cast is not required anymore. See https://github.com/angular/angular/issues/40778

--- a/docs/adoc/microfrontend-platform-developer-guide/chapters/miscellaneous/angular-integration-guide/activator.snippets.ts
+++ b/docs/adoc/microfrontend-platform-developer-guide/chapters/miscellaneous/angular-integration-guide/activator.snippets.ts
@@ -31,7 +31,7 @@ export class ActivatorModule {
 
   // tag::activator-module-using-resolver[]
   constructor() {
-    MicrofrontendPlatform.whenState(PlatformState.Started).then(() => {
+    MicrofrontendPlatform.onState(PlatformState.Started, () => {
       // Perform initialization tasks such as installing message handlers.
     });
   }

--- a/docs/adoc/microfrontend-platform-developer-guide/chapters/miscellaneous/platform-lifecycle/platform-lifecycle.adoc
+++ b/docs/adoc/microfrontend-platform-developer-guide/chapters/miscellaneous/platform-lifecycle/platform-lifecycle.adoc
@@ -90,7 +90,7 @@ When the platform is stopped, it first enters the `Stopping` platform state. In 
 
 The platform allows the application to send messages while the platform is stopping. After all beans are destroyed, the client is disconnected from the host and the platform enters the `Stopped` state.
 
-By default, the platform initiates shutdown when the browser unloads the document, i.e., when `beforeunload` is triggered. The main reason for `beforeunload` instead of `unload` is to avoid posting messages to disposed windows. However, if `beforeunload` is not triggered, e.g., when an iframe is removed, we fall back to `unload`.
+By default, the platform initiates shutdown when the `pagehide` event is triggered and the page is entering the terminated state. See the https://developer.chrome.com/docs/web-platform/page-lifecycle-api[Page Lifecycle API] guide for more information about how this event relates to other events in the page lifecycle.
 
 You can change this behavior by registering a custom `MicrofrontendPlatformStopper` bean, as follows:
 

--- a/docs/adoc/microfrontend-platform-developer-guide/chapters/miscellaneous/platform-lifecycle/platform-lifecycle.adoc
+++ b/docs/adoc/microfrontend-platform-developer-guide/chapters/miscellaneous/platform-lifecycle/platform-lifecycle.adoc
@@ -86,11 +86,11 @@ Running initializers:: Advances the progress after the platform enters the `Star
 [[chapter:platform-lifecycle:platform-shutdown]]
 === Platform Shutdown
 
-When the platform is stopped, it first enters the `Stopping` platform state. In this state, the beans registered with the platform are destroyed. Beans are destroyed according to their destruction order as specified at bean registration. Beans of the same destroy order are destroyed in reverse construction order. Beans can implement the `PreDestroy` lifecycle hook to get notified when they are about to be destroyed.
+When the platform is stopped, it first enters the `Stopping` platform state. In this state, all registered callback functions are executed. Then, the beans registered with the platform are then destroyed. Beans are destroyed according to their destruction order as specified at bean registration. Beans of the same destroy order are destroyed in reverse construction order. Beans can implement the `PreDestroy` lifecycle hook to get notified when they are about to be destroyed.
 
 The platform allows the application to send messages while the platform is stopping. After all beans are destroyed, the client is disconnected from the host and the platform enters the `Stopped` state.
 
-By default, the platform initiates shutdown when the browser unloads the document, i.e., when `beforeunload` is triggered. The main reason for `beforeunload` instead of `unload` is to avoid posting messages to disposed windows. However, if `beforeunload` is not triggered, e.g., when an iframe is removed, we fall back to `unload`.
+By default, the platform initiates shutdown when the `pagehide` event is triggered and the page is entering the terminated state. See the https://developer.chrome.com/docs/web-platform/page-lifecycle-api[Page Lifecycle API] guide for more information about how this event relates to other events in the page lifecycle.
 
 You can change this behavior by registering a custom `MicrofrontendPlatformStopper` bean, as follows:
 

--- a/docs/adoc/microfrontend-platform-developer-guide/chapters/miscellaneous/platform-lifecycle/platform-lifecycle.snippets.ts
+++ b/docs/adoc/microfrontend-platform-developer-guide/chapters/miscellaneous/platform-lifecycle/platform-lifecycle.snippets.ts
@@ -46,16 +46,16 @@ import {MicrofrontendPlatform, MicrofrontendPlatformHost, MicrofrontendPlatformS
 
 {
   // tag::platform-lifecycle:microfrontend-platform-stopper[]
-  class OnUnloadMicrofrontendPlatformStopper implements MicrofrontendPlatformStopper {
+  class CustomMicrofrontendPlatformStopper implements MicrofrontendPlatformStopper {
 
     constructor() {
       // Destroys the platform when the document is about to be unloaded.
-      window.addEventListener('unload', () => MicrofrontendPlatform.destroy(), {once: true});
+      window.addEventListener('beforeunload', () => MicrofrontendPlatform.destroy(), {once: true});
     }
   }
 
   // Registers custom platform stopper.
-  Beans.register(MicrofrontendPlatformStopper, {useClass: OnUnloadMicrofrontendPlatformStopper});
+  Beans.register(MicrofrontendPlatformStopper, {useClass: CustomMicrofrontendPlatformStopper});
   // end::platform-lifecycle:microfrontend-platform-stopper[]
 }
 

--- a/docs/adoc/microfrontend-platform-developer-guide/chapters/miscellaneous/platform-lifecycle/platform-lifecycle.snippets.ts
+++ b/docs/adoc/microfrontend-platform-developer-guide/chapters/miscellaneous/platform-lifecycle/platform-lifecycle.snippets.ts
@@ -14,19 +14,19 @@ import {MicrofrontendPlatform, MicrofrontendPlatformHost, MicrofrontendPlatformS
 
 {
   // tag::platform-lifecycle:when-state[]
-  MicrofrontendPlatform.whenState(PlatformState.Starting).then(() => {
+  MicrofrontendPlatform.onState(PlatformState.Starting, () => {
     // invoked when the platform is about to start.
   });
 
-  MicrofrontendPlatform.whenState(PlatformState.Started).then(() => {
+  MicrofrontendPlatform.onState(PlatformState.Started, () => {
     // invoked after the platform is started
   });
 
-  MicrofrontendPlatform.whenState(PlatformState.Stopping).then(() => {
+  MicrofrontendPlatform.onState(PlatformState.Stopping, () => {
     // invoked when the platform is about to stop.
   });
 
-  MicrofrontendPlatform.whenState(PlatformState.Stopped).then(() => {
+  MicrofrontendPlatform.onState(PlatformState.Stopped, () => {
     // invoked when the platform is stopped.
   });
   // end::platform-lifecycle:when-state[]
@@ -46,16 +46,16 @@ import {MicrofrontendPlatform, MicrofrontendPlatformHost, MicrofrontendPlatformS
 
 {
   // tag::platform-lifecycle:microfrontend-platform-stopper[]
-  class OnUnloadMicrofrontendPlatformStopper implements MicrofrontendPlatformStopper {
+  class CustomMicrofrontendPlatformStopper implements MicrofrontendPlatformStopper {
 
     constructor() {
-      // Destroys the platform when the document is about to be unloaded.
-      window.addEventListener('unload', () => MicrofrontendPlatform.destroy(), {once: true});
+      // Destroys the platform before the document is unloaded.
+      window.addEventListener('beforeunload', () => MicrofrontendPlatform.destroy());
     }
   }
 
   // Registers custom platform stopper.
-  Beans.register(MicrofrontendPlatformStopper, {useClass: OnUnloadMicrofrontendPlatformStopper});
+  Beans.register(MicrofrontendPlatformStopper, {useClass: CustomMicrofrontendPlatformStopper});
   // end::platform-lifecycle:microfrontend-platform-stopper[]
 }
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "before-push": "run-s build lint \"test:headless -- --no-watch\" e2e:headless",
     "build": "run-s **:*:build **:*:typedoc",
     "start": "run-p -r microfrontend-platform-testing-app:*:serve microfrontend-platform-devtools:serve",
+    "start-zone": "run-p -r microfrontend-platform-testing-app:*:serve-zone microfrontend-platform-devtools:serve",
     "lint": "run-p **:*:lint",
     "test": "run-p \"microfrontend-platform-testing-scripts:build -- --watch\" \"**:*:test\"",
     "test:headless": "cross-env HEADLESS=true run-s test",

--- a/projects/scion/microfrontend-platform.e2e/src/messaging/messaging.e2e-spec.ts
+++ b/projects/scion/microfrontend-platform.e2e/src/messaging/messaging.e2e-spec.ts
@@ -95,7 +95,7 @@ test.describe('Messaging', () => {
       await TopicBasedMessagingSpecs.passHeadersSpec(testingAppPO);
     });
 
-    test('should stop platform in `beforeunload` to avoid posting messages to disposed windows', async ({testingAppPO, consoleLogs}) => {
+    test('should not post messages to disposed windows', async ({testingAppPO, consoleLogs}) => {
       await TopicBasedMessagingSpecs.doNotPostMessageToDisposedWindow(testingAppPO, consoleLogs);
     });
 

--- a/projects/scion/microfrontend-platform/src/lib/client/client-connect.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/client/client-connect.spec.ts
@@ -22,13 +22,13 @@ describe('MicrofrontendPlatform', () => {
 
   const disposables = new Set<Disposable>();
 
-  beforeEach(async () => {
-    await MicrofrontendPlatform.destroy();
+  beforeEach(() => {
+    MicrofrontendPlatform.destroy();
     installLoggerSpies();
   });
 
-  afterEach(async () => {
-    await MicrofrontendPlatform.destroy();
+  afterEach(() => {
+    MicrofrontendPlatform.destroy();
     disposables.forEach(disposable => disposable());
   });
 

--- a/projects/scion/microfrontend-platform/src/lib/client/client-disconnect.script.ts
+++ b/projects/scion/microfrontend-platform/src/lib/client/client-disconnect.script.ts
@@ -32,7 +32,7 @@ export async function connectToHost(args: {symbolicName: string; disconnectOnUnl
 export async function connectToHostThenStopPlatform(args: {symbolicName: string}, observer: Observer<string>): Promise<void> {
   await MicrofrontendPlatformClient.connect(args.symbolicName);
   observer.next(Beans.get(ɵBrokerGateway).session!.clientId);
-  await MicrofrontendPlatform.destroy();
+  MicrofrontendPlatform.destroy();
 }
 
 export async function connectToHostThenLocationHref(args: {symbolicName: string; locationHref: string}, observer: Observer<string>): Promise<void> {

--- a/projects/scion/microfrontend-platform/src/lib/client/client-disconnect.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/client/client-disconnect.spec.ts
@@ -22,13 +22,13 @@ describe('MicrofrontendPlatform', () => {
 
   const disposables = new Set<Disposable>();
 
-  beforeEach(async () => {
-    await MicrofrontendPlatform.destroy();
+  beforeEach(() => {
+    MicrofrontendPlatform.destroy();
     installLoggerSpies();
   });
 
-  afterEach(async () => {
-    await MicrofrontendPlatform.destroy();
+  afterEach(() => {
+    MicrofrontendPlatform.destroy();
     disposables.forEach(disposable => disposable());
   });
 

--- a/projects/scion/microfrontend-platform/src/lib/client/context/context.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/client/context/context.spec.ts
@@ -16,8 +16,8 @@ import {ObserveCaptor} from '@scion/toolkit/testing';
 
 describe('Context', () => {
 
-  beforeEach(async () => await MicrofrontendPlatform.destroy());
-  afterEach(async () => await MicrofrontendPlatform.destroy());
+  beforeEach(() => MicrofrontendPlatform.destroy());
+  afterEach(() => MicrofrontendPlatform.destroy());
 
   it('should not complete the Observable when looking up context values from inside the host app (no context)', async () => {
     await MicrofrontendPlatformHost.start({applications: []});

--- a/projects/scion/microfrontend-platform/src/lib/client/manifest-registry/manifest-service.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/client/manifest-registry/manifest-service.spec.ts
@@ -24,8 +24,8 @@ const manifestObjectIdsExtractFn = (manifestObjects: Array<Capability | Intentio
 
 describe('ManifestService', () => {
 
-  beforeEach(async () => await MicrofrontendPlatform.destroy());
-  afterEach(async () => await MicrofrontendPlatform.destroy());
+  beforeEach(() => MicrofrontendPlatform.destroy());
+  afterEach(() => MicrofrontendPlatform.destroy());
 
   describe('Application', () => {
     it('should return applications', async () => {

--- a/projects/scion/microfrontend-platform/src/lib/client/messaging/broker-gateway.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/client/messaging/broker-gateway.spec.ts
@@ -17,8 +17,8 @@ import {IntentSubscribeCommand, MessagingChannel, TopicSubscribeCommand} from '.
 
 describe('BrokerGateway', () => {
 
-  beforeEach(async () => await MicrofrontendPlatform.destroy());
-  afterEach(async () => await MicrofrontendPlatform.destroy());
+  beforeEach(() => MicrofrontendPlatform.destroy());
+  afterEach(() => MicrofrontendPlatform.destroy());
 
   it('should not complete `requestReply$` Observable upon platform shutdown (as per API)', async () => {
     await MicrofrontendPlatformHost.start({applications: []});
@@ -28,7 +28,7 @@ describe('BrokerGateway', () => {
     const message: TopicMessage = {topic: 'topic', headers: new Map()};
     Beans.get(BrokerGateway).requestReply$(MessagingChannel.Topic, message).subscribe(captor);
     // WHEN
-    await MicrofrontendPlatform.destroy();
+    MicrofrontendPlatform.destroy();
     // THEN
     expect(captor.hasCompleted()).toBeFalse();
     expect(captor.hasErrored()).toBeFalse();
@@ -48,7 +48,7 @@ describe('BrokerGateway', () => {
     };
     Beans.get(BrokerGateway).subscribe$(descriptor).subscribe(captor);
     // WHEN
-    await MicrofrontendPlatform.destroy();
+    MicrofrontendPlatform.destroy();
     // THEN
     expect(captor.hasCompleted()).toBeFalse();
     expect(captor.hasErrored()).toBeFalse();
@@ -68,7 +68,7 @@ describe('BrokerGateway', () => {
     };
     Beans.get(BrokerGateway).subscribe$(descriptor).subscribe(captor);
     // WHEN
-    await MicrofrontendPlatform.destroy();
+    MicrofrontendPlatform.destroy();
     // THEN
     expect(captor.hasCompleted()).toBeFalse();
     expect(captor.hasErrored()).toBeFalse();

--- a/projects/scion/microfrontend-platform/src/lib/client/messaging/message-handler.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/client/messaging/message-handler.spec.ts
@@ -26,9 +26,9 @@ describe('Message Handler', () => {
 
   const disposables = new Set<Disposable>();
 
-  beforeEach(async () => await MicrofrontendPlatform.destroy());
-  afterEach(async () => {
-    await MicrofrontendPlatform.destroy();
+  beforeEach(() => MicrofrontendPlatform.destroy());
+  afterEach(() => {
+    MicrofrontendPlatform.destroy();
     disposables.forEach(disposable => disposable());
   });
 
@@ -564,9 +564,9 @@ describe('Intent Handler', () => {
 
   const disposables = new Set<Disposable>();
 
-  beforeEach(async () => await MicrofrontendPlatform.destroy());
-  afterEach(async () => {
-    await MicrofrontendPlatform.destroy();
+  beforeEach(() => MicrofrontendPlatform.destroy());
+  afterEach(() => {
+    MicrofrontendPlatform.destroy();
     disposables.forEach(disposable => disposable());
   });
 

--- a/projects/scion/microfrontend-platform/src/lib/client/messaging/messaging.script.ts
+++ b/projects/scion/microfrontend-platform/src/lib/client/messaging/messaging.script.ts
@@ -26,10 +26,10 @@ export async function connectToHost(args: {symbolicName: string}): Promise<void>
   await MicrofrontendPlatformClient.connect(args.symbolicName);
 }
 
-export async function sendMessageWhenPlatformStateStopping(args: {symbolicName: string}): Promise<void> {
+export async function sendMessageOnPlatformStateStopping(args: {symbolicName: string}): Promise<void> {
   await MicrofrontendPlatformClient.connect(args.symbolicName);
-  void MicrofrontendPlatform.whenState(PlatformState.Stopping).then(async () => {
-    await Beans.get(MessageClient).publish(`${args.symbolicName}/whenPlatformStateStopping`, 'message from client');
+  MicrofrontendPlatform.onState(PlatformState.Stopping, () => {
+    void Beans.get(MessageClient).publish(`${args.symbolicName}/whenPlatformStateStopping`, 'message from client');
   });
 }
 
@@ -42,20 +42,6 @@ export async function sendMessageOnBeanPreDestroy(args: {symbolicName: string}):
 
   Beans.register(LifecycleHook, {eager: true});
   await MicrofrontendPlatformClient.connect(args.symbolicName);
-}
-
-export async function sendMessageInBeforeUnload(args: {symbolicName: string}): Promise<void> {
-  await MicrofrontendPlatformClient.connect(args.symbolicName);
-  fromEvent(window, 'beforeunload', {once: true}).subscribe(() => {
-    void Beans.get(MessageClient).publish(`${args.symbolicName}/beforeunload`, 'message from client');
-  });
-}
-
-export async function sendMessageInUnload(args: {symbolicName: string}): Promise<void> {
-  await MicrofrontendPlatformClient.connect(args.symbolicName);
-  fromEvent(window, 'unload', {once: true}).subscribe(() => {
-    void Beans.get(MessageClient).publish(`${args.symbolicName}/unload`, 'message from client');
-  });
 }
 
 export async function subscribeToTopic(args: {symbolicName: string; topic: string; monitorTopicMessageChannel?: boolean}, observer: Observer<TopicMessage>): Promise<void> {

--- a/projects/scion/microfrontend-platform/src/lib/client/messaging/messaging.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/client/messaging/messaging.spec.ts
@@ -32,13 +32,13 @@ describe('Messaging', () => {
 
   const disposables = new Set<Disposable>();
 
-  beforeEach(async () => {
-    await MicrofrontendPlatform.destroy();
+  beforeEach(() => {
+    MicrofrontendPlatform.destroy();
     installLoggerSpies();
   });
 
-  afterEach(async () => {
-    await MicrofrontendPlatform.destroy();
+  afterEach(() => {
+    MicrofrontendPlatform.destroy();
     disposables.forEach(disposable => disposable());
   });
 
@@ -55,7 +55,7 @@ describe('Messaging', () => {
     await expectEmissions(messageCaptor).toEqual(['A', 'B', 'C']);
   });
 
-  it('should allow publishing a message in the platform\'s `whenState(PlatformState.Stopping)` hook', async () => {
+  it('should allow publishing a message in the platform\'s `onState(PlatformState.Stopping)` hook', async () => {
     await MicrofrontendPlatformHost.start({
       applications: [
         {
@@ -69,7 +69,7 @@ describe('Messaging', () => {
     Beans.get(MessageClient).observe$<string>('client/whenPlatformStateStopping').subscribe(captor);
 
     const microfrontendFixture = registerFixture(new MicrofrontendFixture());
-    await microfrontendFixture.insertIframe().loadScript('lib/client/messaging/messaging.script.ts', 'sendMessageWhenPlatformStateStopping', {symbolicName: 'client'});
+    await microfrontendFixture.insertIframe().loadScript('lib/client/messaging/messaging.script.ts', 'sendMessageOnPlatformStateStopping', {symbolicName: 'client'});
     microfrontendFixture.removeIframe();
     await expectEmissions(captor).toEqual(['message from client']);
   });
@@ -89,48 +89,6 @@ describe('Messaging', () => {
 
     const microfrontendFixture = registerFixture(new MicrofrontendFixture());
     await microfrontendFixture.insertIframe().loadScript('lib/client/messaging/messaging.script.ts', 'sendMessageOnBeanPreDestroy', {symbolicName: 'client'});
-    microfrontendFixture.removeIframe();
-    await expectEmissions(captor).toEqual(['message from client']);
-  });
-
-  it('should allow publishing a message in `window.beforeunload` browser hook', async () => {
-    await MicrofrontendPlatformHost.start({
-      applications: [
-        {
-          symbolicName: 'client',
-          manifestUrl: new ManifestFixture({name: 'Client'}).serve(),
-        },
-      ],
-    });
-
-    const captor = new ObserveCaptor<TopicMessage<string>, string>(msg => msg.body!);
-    Beans.get(MessageClient).observe$<string>('client/beforeunload').subscribe(captor);
-
-    const microfrontendFixture = registerFixture(new MicrofrontendFixture());
-    await microfrontendFixture.insertIframe().loadScript('lib/client/messaging/messaging.script.ts', 'sendMessageInBeforeUnload', {symbolicName: 'client'});
-
-    // The browser does not trigger the 'beforeunload' event when removing the iframe.
-    // For that reason, we navigate to another side.
-    microfrontendFixture.setUrl('about:blank');
-    await expectEmissions(captor).toEqual(['message from client']);
-  });
-
-  it('should allow publishing a message in `window.unload` browser hook', async () => {
-    await MicrofrontendPlatformHost.start({
-      applications: [
-        {
-          symbolicName: 'client',
-          manifestUrl: new ManifestFixture({name: 'Client'}).serve(),
-        },
-      ],
-    });
-
-    const captor = new ObserveCaptor<TopicMessage<string>, string>(msg => msg.body!);
-    Beans.get(MessageClient).observe$<string>('client/unload').subscribe(captor);
-
-    const microfrontendFixture = registerFixture(new MicrofrontendFixture());
-    await microfrontendFixture.insertIframe().loadScript('lib/client/messaging/messaging.script.ts', 'sendMessageInUnload', {symbolicName: 'client'});
-
     microfrontendFixture.removeIframe();
     await expectEmissions(captor).toEqual(['message from client']);
   });
@@ -403,7 +361,7 @@ describe('Messaging', () => {
     const captor = new ObserveCaptor();
     Beans.get(MessageClient).observe$('topic').subscribe(captor);
     // WHEN
-    await MicrofrontendPlatform.destroy();
+    MicrofrontendPlatform.destroy();
     // THEN
     expect(captor.hasCompleted()).withContext('hasCompleted').toBeFalse();
     expect(captor.hasErrored()).withContext('hasErrored').toBeFalse();
@@ -419,7 +377,7 @@ describe('Messaging', () => {
     Beans.get(MessageClient).request$('topic').subscribe(captor);
     await waitUntilSubscriberCount('topic', 1);
     // WHEN
-    await MicrofrontendPlatform.destroy();
+    MicrofrontendPlatform.destroy();
     // THEN
     expect(captor.hasCompleted()).withContext('hasCompleted').toBeFalse();
     expect(captor.hasErrored()).withContext('hasErrored').toBeFalse();
@@ -1067,7 +1025,7 @@ describe('Messaging', () => {
     const captor = new ObserveCaptor();
     Beans.get(MessageClient).subscriberCount$('topic').subscribe(captor);
     // WHEN
-    await MicrofrontendPlatform.destroy();
+    MicrofrontendPlatform.destroy();
     // THEN
     expect(captor.hasCompleted()).withContext('hasCompleted').toBeFalse();
     expect(captor.hasErrored()).withContext('hasErrored').toBeFalse();
@@ -1250,7 +1208,7 @@ describe('Messaging', () => {
         .pipe(takeUntilUnsubscribe('nobody-subscribed-to-this-topic'))
         .subscribe(captor);
       // WHEN
-      await MicrofrontendPlatform.destroy();
+      MicrofrontendPlatform.destroy();
       // THEN
       expect(captor.hasCompleted()).withContext('hasCompleted').toBeFalse();
       expect(captor.hasErrored()).withContext('hasErrored').toBeFalse();

--- a/projects/scion/microfrontend-platform/src/lib/client/preferred-size/preferred-size.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/client/preferred-size/preferred-size.spec.ts
@@ -19,12 +19,10 @@ describe('PreferredSize', () => {
 
   const disposables = new Set<Disposable>();
 
-  beforeEach(async () => {
-    await MicrofrontendPlatform.destroy();
-  });
+  beforeEach(() => MicrofrontendPlatform.destroy());
 
-  afterEach(async () => {
-    await MicrofrontendPlatform.destroy();
+  afterEach(() => {
+    MicrofrontendPlatform.destroy();
     disposables.forEach(disposable => disposable());
   });
 

--- a/projects/scion/microfrontend-platform/src/lib/client/preferred-size/preferred-size.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/client/preferred-size/preferred-size.spec.ts
@@ -19,12 +19,12 @@ describe('PreferredSize', () => {
 
   const disposables = new Set<Disposable>();
 
-  beforeEach(async () => {
-    await MicrofrontendPlatform.destroy();
+  beforeEach(() => {
+    MicrofrontendPlatform.destroy();
   });
 
-  afterEach(async () => {
-    await MicrofrontendPlatform.destroy();
+  afterEach(() => {
+    MicrofrontendPlatform.destroy();
     disposables.forEach(disposable => disposable());
   });
 

--- a/projects/scion/microfrontend-platform/src/lib/client/router-outlet/named-parameter-substitution.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/client/router-outlet/named-parameter-substitution.spec.ts
@@ -24,8 +24,8 @@ describe('OutletRouter', () => {
 
   describe('Named parameter substitution', () => {
 
-    beforeAll(async () => await MicrofrontendPlatformHost.start({applications: []}));
-    afterAll(async () => await MicrofrontendPlatform.destroy());
+    beforeAll(() => MicrofrontendPlatformHost.start({applications: []}));
+    afterAll(() => MicrofrontendPlatform.destroy());
 
     describe('absolute URL (hash-based routing)', () => testSubstitution('http://localhost:4200/#/', {expectedBasePath: 'http://localhost:4200/#/'}));
     describe('absolute URL (push-state routing)', () => testSubstitution('http://localhost:4200/', {expectedBasePath: 'http://localhost:4200/'}));

--- a/projects/scion/microfrontend-platform/src/lib/client/router-outlet/named-parameter-substitution.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/client/router-outlet/named-parameter-substitution.spec.ts
@@ -25,7 +25,7 @@ describe('OutletRouter', () => {
   describe('Named parameter substitution', () => {
 
     beforeAll(async () => await MicrofrontendPlatformHost.start({applications: []}));
-    afterAll(async () => await MicrofrontendPlatform.destroy());
+    afterAll(() => MicrofrontendPlatform.destroy());
 
     describe('absolute URL (hash-based routing)', () => testSubstitution('http://localhost:4200/#/', {expectedBasePath: 'http://localhost:4200/#/'}));
     describe('absolute URL (push-state routing)', () => testSubstitution('http://localhost:4200/', {expectedBasePath: 'http://localhost:4200/'}));

--- a/projects/scion/microfrontend-platform/src/lib/client/router-outlet/outlet-router.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/client/router-outlet/outlet-router.spec.ts
@@ -17,8 +17,8 @@ import {take} from 'rxjs/operators';
 
 describe('OutletRouter', () => {
 
-  beforeEach(async () => await MicrofrontendPlatform.destroy());
-  afterEach(async () => await MicrofrontendPlatform.destroy());
+  beforeEach(() => MicrofrontendPlatform.destroy());
+  afterEach(() => MicrofrontendPlatform.destroy());
 
   it('should support navigating to blob URL', async () => {
     await MicrofrontendPlatformHost.start({applications: []});

--- a/projects/scion/microfrontend-platform/src/lib/client/router-outlet/relative-path-resolver.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/client/router-outlet/relative-path-resolver.spec.ts
@@ -15,7 +15,7 @@ import {Beans} from '@scion/toolkit/bean-manager';
 describe('RelativePathResolver', () => {
 
   beforeEach(async () => await MicrofrontendPlatform.startPlatform(() => void Beans.register(RelativePathResolver)));
-  afterEach(async () => await MicrofrontendPlatform.destroy());
+  afterEach(() => MicrofrontendPlatform.destroy());
 
   describe('hash-based routing', () => {
 

--- a/projects/scion/microfrontend-platform/src/lib/host/activator/activator-installer.ts
+++ b/projects/scion/microfrontend-platform/src/lib/host/activator/activator-installer.ts
@@ -142,6 +142,6 @@ export class ActivatorInstaller implements Initializer {
     // Add the router outlet to the DOM
     document.body.appendChild(routerOutlet);
     // Unmount the router outlet on platform shutdown
-    void MicrofrontendPlatform.whenState(PlatformState.Stopped).then(() => document.body.removeChild(routerOutlet));
+    MicrofrontendPlatform.onState(PlatformState.Stopped, () => document.body.removeChild(routerOutlet));
   }
 }

--- a/projects/scion/microfrontend-platform/src/lib/host/app-installer.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/host/app-installer.spec.ts
@@ -19,8 +19,8 @@ import {ManifestFixture} from '../testing/manifest-fixture/manifest-fixture';
 
 describe('AppInstaller', () => {
 
-  beforeEach(async () => await MicrofrontendPlatform.destroy());
-  afterEach(async () => await MicrofrontendPlatform.destroy());
+  beforeEach(() => MicrofrontendPlatform.destroy());
+  afterEach(() => MicrofrontendPlatform.destroy());
 
   it('should fetch and register applications', async () => {
     // mock {HttpClient}

--- a/projects/scion/microfrontend-platform/src/lib/host/application-registry.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/host/application-registry.spec.ts
@@ -22,7 +22,7 @@ describe('ApplicationRegistry', () => {
   let registry: ApplicationRegistry;
 
   beforeEach(async () => {
-    await MicrofrontendPlatform.destroy();
+    MicrofrontendPlatform.destroy();
     await MicrofrontendPlatform.startPlatform(() => {
       Beans.register(MicrofrontendPlatformConfig);
       Beans.register(ApplicationRegistry);
@@ -32,7 +32,7 @@ describe('ApplicationRegistry', () => {
     });
     registry = Beans.get(ApplicationRegistry);
   });
-  afterEach(async () => await MicrofrontendPlatform.destroy());
+  afterEach(() => MicrofrontendPlatform.destroy());
 
   describe('app base URL', () => {
 

--- a/projects/scion/microfrontend-platform/src/lib/host/client-registry/client.registry.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/host/client-registry/client.registry.spec.ts
@@ -17,8 +17,8 @@ import {ɵApplication, ɵVERSION} from '../../ɵplatform.model';
 
 describe('ClientRegistry', () => {
 
-  beforeEach(async () => await MicrofrontendPlatform.destroy());
-  afterEach(async () => await MicrofrontendPlatform.destroy());
+  beforeEach(() => MicrofrontendPlatform.destroy());
+  afterEach(() => MicrofrontendPlatform.destroy());
 
   it('should register a client by its id', async () => {
     await MicrofrontendPlatformHost.start({applications: []});

--- a/projects/scion/microfrontend-platform/src/lib/host/client-registry/ɵclient.registry.ts
+++ b/projects/scion/microfrontend-platform/src/lib/host/client-registry/ɵclient.registry.ts
@@ -29,7 +29,7 @@ export class ɵClientRegistry implements ClientRegistry, PreDestroy {
       Beans.get(Logger).warn(
         `[StaleClient] Stale client registration detected when loading application '${client.application.symbolicName}'
         into the window of '${staleClient.application.symbolicName}'. Removing stale registration. Most likely, the client could not disconnect
-        from the broker, for example, because the client was disposed without notice, i.e., without receiving the browser's "unload" event, or
+        from the broker, for example, because the client was disposed without notice, i.e., without receiving the browser's "pagehide" event, or
         because the browser discarded the 'DISCONNECT' message, maybe due to a high load on the client during unloading.`.replace(/\s+/g, ' '),
         new LoggingContext(staleClient.application.symbolicName, staleClient.version),
       );

--- a/projects/scion/microfrontend-platform/src/lib/host/client-registry/ɵclient.ts
+++ b/projects/scion/microfrontend-platform/src/lib/host/client-registry/ɵclient.ts
@@ -40,7 +40,7 @@ export class ɵClient implements Client {
    * Liveness is detected by sending ping requests at regular intervals.
    *
    * A client may fail to disconnect from the broker for a number of reasons:
-   * - The client was disposed without notice, i.e., without receiving the browser's "unload" event.
+   * - The client was disposed without notice, i.e., without receiving the browser's "pagehide" event.
    * - The browser discarded the "DISCONNECT" message because the client window became stale.
    *   Typically, the browser discards messages for windows that are already closed or if another page
    *   has been loaded into the window, both indicating a high load on the client during unloading.
@@ -79,7 +79,7 @@ export class ɵClient implements Client {
     Beans.get(Logger).warn(
       `[StaleClient] Stale client registration of application '${this.application.symbolicName}' detected.
        Removing stale registration. Most likely, the client could not disconnect from the broker, for example, because the client was
-       disposed without notice, i.e., without receiving the browser's "unload" event, or because the browser discarded the 'DISCONNECT'
+       disposed without notice, i.e., without receiving the browser's "pagehide" event, or because the browser discarded the 'DISCONNECT'
        message. Typically, the browser discards messages for windows that are already closed or if another page has been loaded into the
        window, both indicating a high load on the client during unloading.`.replace(/\s+/g, ' '),
       new LoggingContext(this.application.symbolicName, this.version),

--- a/projects/scion/microfrontend-platform/src/lib/host/host-app-config-provider.ts
+++ b/projects/scion/microfrontend-platform/src/lib/host/host-app-config-provider.ts
@@ -59,6 +59,6 @@ function provideHostManifestUrl(hostManifest: string | Manifest | undefined): st
 
 function serveHostManifest(manifest: Manifest): string {
   const url = URL.createObjectURL(new Blob([JSON.stringify(manifest)], {type: 'application/json'}));
-  void MicrofrontendPlatform.whenState(PlatformState.Stopped).then(() => URL.revokeObjectURL(url));
+  MicrofrontendPlatform.onState(PlatformState.Stopped, () => URL.revokeObjectURL(url));
   return url;
 }

--- a/projects/scion/microfrontend-platform/src/lib/host/manifest-registry/manifest-registry.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/host/manifest-registry/manifest-registry.spec.ts
@@ -25,11 +25,11 @@ const capabilityIdExtractFn = (capability: Capability): string => capability.met
 
 describe('ManifestRegistry', () => {
 
-  beforeEach(async () => {
-    await MicrofrontendPlatform.destroy();
+  beforeEach(() => {
+    MicrofrontendPlatform.destroy();
     installLoggerSpies();
   });
-  afterEach(async () => await MicrofrontendPlatform.destroy());
+  afterEach(() => MicrofrontendPlatform.destroy());
 
   describe('Capability Registration', () => {
 

--- a/projects/scion/microfrontend-platform/src/lib/host/message-broker/message-interceptors.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/host/message-broker/message-interceptors.spec.ts
@@ -119,7 +119,7 @@ describe('Message Interceptors', () => {
     }();
 
     // Register app-specific interceptor when starting the platform.
-    void MicrofrontendPlatform.whenState(PlatformState.Starting).then(() => {
+    MicrofrontendPlatform.onState(PlatformState.Starting, () => {
       Beans.register(MessageInterceptor, {useValue: appInterceptor, multi: true});
     });
 

--- a/projects/scion/microfrontend-platform/src/lib/host/microfrontend-platform-host.ts
+++ b/projects/scion/microfrontend-platform/src/lib/host/microfrontend-platform-host.ts
@@ -116,7 +116,7 @@ export class MicrofrontendPlatformHost {
       const progress$ = defer(() => Beans.get(StartupProgressMonitor).progress$).pipe(takeUntil(unsubscribe$));
 
       if (MicrofrontendPlatform.state === PlatformState.Stopped) {
-        void MicrofrontendPlatform.whenState(PlatformState.Starting).then(() => progress$.subscribe(observer));
+        MicrofrontendPlatform.onState(PlatformState.Starting, () => void progress$.subscribe(observer));
       }
       else {
         progress$.subscribe(observer);
@@ -211,7 +211,7 @@ function provideStartupProgressMonitor(): void {
   Beans.register(StartupProgressMonitor, {useValue: monitor});
   Beans.register(ManifestLoadProgressMonitor, {useValue: manifestLoadProgressMonitor});
   Beans.register(ActivatorLoadProgressMonitor, {useValue: activatorLoadProgressMonitor});
-  void MicrofrontendPlatform.whenState(PlatformState.Started).then(() => platformProgressMonitor.done());
+  MicrofrontendPlatform.onState(PlatformState.Started, () => platformProgressMonitor.done());
 }
 
 /**

--- a/projects/scion/microfrontend-platform/src/lib/host/startup-progress.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/host/startup-progress.spec.ts
@@ -29,7 +29,7 @@ describe('StartupProgress', () => {
     expect(captor1.hasCompleted()).toBeTrue();
 
     // Stop the platform
-    await MicrofrontendPlatform.destroy();
+    MicrofrontendPlatform.destroy();
 
     // Start the platform again
     const captor2 = new ObserveCaptor();
@@ -63,7 +63,7 @@ describe('StartupProgress', () => {
     expect(captor1.getLastValue()).toEqual(100);
     expect(captor1.hasCompleted()).toBeTrue();
 
-    await MicrofrontendPlatform.destroy();
+    MicrofrontendPlatform.destroy();
     // Expect no emission if the platform is not yet started
     const captor2 = new ObserveCaptor<number>();
     MicrofrontendPlatformHost.startupProgress$.subscribe(captor2);

--- a/projects/scion/microfrontend-platform/src/lib/microfrontend-platform-stopper.ts
+++ b/projects/scion/microfrontend-platform/src/lib/microfrontend-platform-stopper.ts
@@ -7,17 +7,12 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {PreDestroy} from '@scion/toolkit/bean-manager';
 import {MicrofrontendPlatform} from './microfrontend-platform';
-import {fromEvent, race, Subject} from 'rxjs';
-import {take, takeUntil} from 'rxjs/operators';
 
 /**
  * Stops the platform and disconnects this client from the host when the browser unloads the document.
  *
- * By default, the platform initiates shutdown when the browser unloads the document, i.e., when `beforeunload` is triggered.
- * The main reason for `beforeunload` instead of `unload` is to avoid posting messages to disposed windows.
- * However, if `beforeunload` is not triggered, e.g., when an iframe is removed, we fall back to `unload`.
+ * By default, the platform initiates shutdown when the `pagehide` event is triggered and the page is entering the terminated state.
  *
  * @category Platform
  */
@@ -27,22 +22,16 @@ export abstract class MicrofrontendPlatformStopper {
 /**
  * @internal
  */
-export class ɵMicrofrontendPlatformStopper implements MicrofrontendPlatformStopper, PreDestroy {
-
-  private _destroy$ = new Subject<void>();
+export class ɵMicrofrontendPlatformStopper implements MicrofrontendPlatformStopper {
 
   constructor() {
-    race(fromEvent(window, 'beforeunload'), fromEvent(window, 'unload'))
-      .pipe(
-        take(1),
-        takeUntil(this._destroy$),
-      )
-      .subscribe(() => {
-        void MicrofrontendPlatform.destroy();
-      });
-  }
-
-  public preDestroy(): void {
-    this._destroy$.next();
+    window.addEventListener('pagehide', event => {
+      // Destroy microfrontend platform only if the page is entering the `terminated` state.
+      // https://developer.chrome.com/docs/web-platform/page-lifecycle-api#event-pagehide
+      // https://developer.chrome.com/docs/web-platform/page-lifecycle-api/image/page-lifecycle-api-state.svg
+      if (!event.persisted) {
+        MicrofrontendPlatform.destroy();
+      }
+    }, {once: true});
   }
 }

--- a/projects/scion/microfrontend-platform/src/lib/microfrontend-platform-stopper.ts
+++ b/projects/scion/microfrontend-platform/src/lib/microfrontend-platform-stopper.ts
@@ -7,17 +7,12 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {PreDestroy} from '@scion/toolkit/bean-manager';
 import {MicrofrontendPlatform} from './microfrontend-platform';
-import {fromEvent, race, Subject} from 'rxjs';
-import {take, takeUntil} from 'rxjs/operators';
 
 /**
  * Stops the platform and disconnects this client from the host when the browser unloads the document.
  *
- * By default, the platform initiates shutdown when the browser unloads the document, i.e., when `beforeunload` is triggered.
- * The main reason for `beforeunload` instead of `unload` is to avoid posting messages to disposed windows.
- * However, if `beforeunload` is not triggered, e.g., when an iframe is removed, we fall back to `unload`.
+ * By default, the platform initiates shutdown when the `pagehide` event is triggered and the page is entering the terminated state.
  *
  * @category Platform
  */
@@ -27,22 +22,16 @@ export abstract class MicrofrontendPlatformStopper {
 /**
  * @internal
  */
-export class ɵMicrofrontendPlatformStopper implements MicrofrontendPlatformStopper, PreDestroy {
-
-  private _destroy$ = new Subject<void>();
+export class ɵMicrofrontendPlatformStopper implements MicrofrontendPlatformStopper {
 
   constructor() {
-    race(fromEvent(window, 'beforeunload'), fromEvent(window, 'unload'))
-      .pipe(
-        take(1),
-        takeUntil(this._destroy$),
-      )
-      .subscribe(() => {
-        void MicrofrontendPlatform.destroy();
-      });
-  }
-
-  public preDestroy(): void {
-    this._destroy$.next();
+    window.addEventListener('pagehide', event => {
+      // Destroy microfrontend platform only if the page is entering the `terminated` state.
+      // https://developer.chrome.com/docs/web-platform/page-lifecycle-api#event-pagehide
+      // https://developer.chrome.com/docs/web-platform/page-lifecycle-api/image/page-lifecycle-api-state.svg
+      if (!event.persisted) {
+        MicrofrontendPlatform.destroy();
+      }
+    });
   }
 }

--- a/projects/scion/microfrontend-platform/src/lib/microfrontend-platform.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/microfrontend-platform.spec.ts
@@ -13,13 +13,13 @@ import {MicrofrontendPlatformHost} from './host/microfrontend-platform-host';
 import {MicrofrontendPlatformClient} from './client/microfrontend-platform-client';
 import {waitFor} from './testing/spec.util.spec';
 import {PlatformState} from './platform-state';
-import {Beans} from '@scion/toolkit/bean-manager';
+import {Beans, PreDestroy} from '@scion/toolkit/bean-manager';
 import {PlatformPropertyService} from './platform-property-service';
 
 describe('MicrofrontendPlatform', () => {
 
-  beforeEach(async () => await MicrofrontendPlatform.destroy());
-  afterEach(async () => await MicrofrontendPlatform.destroy());
+  beforeEach(() => MicrofrontendPlatform.destroy());
+  afterEach(() => MicrofrontendPlatform.destroy());
 
   it('should report that the app is not connected to the platform host when the host platform is not found', async () => {
     const startup = MicrofrontendPlatformClient.connect('client-app', {brokerDiscoverTimeout: 250});
@@ -241,6 +241,33 @@ describe('MicrofrontendPlatform', () => {
       .set('prop2', 'PROP2')
       .set('prop3', 'PROP3'),
     );
+  });
+
+  it('should shutdown platform synchronously', async () => {
+    // GIVEN
+    const log: string[] = [];
+
+    class Bean implements PreDestroy {
+      public preDestroy(): void {
+        log.push(`bean destroyed [state=${MicrofrontendPlatform.state}]`);
+      }
+    }
+
+    Beans.register(Bean, {eager: true});
+
+    await MicrofrontendPlatform.startPlatform();
+    MicrofrontendPlatform.onState(PlatformState.Stopping, () => log.push(`microfrontend platform stopping [state=${MicrofrontendPlatform.state}]`));
+    MicrofrontendPlatform.onState(PlatformState.Stopped, () => log.push(`microfrontend platform stopped [state=${MicrofrontendPlatform.state}]`));
+
+    // WHEN
+    MicrofrontendPlatform.destroy();
+
+    // THEN
+    expect(log).toEqual([
+      `microfrontend platform stopping [state=${PlatformState.Stopping}]`,
+      `bean destroyed [state=${PlatformState.Stopping}]`,
+      `microfrontend platform stopped [state=${PlatformState.Stopped}]`,
+    ]);
   });
 });
 

--- a/projects/scion/microfrontend-platform/src/lib/microfrontend-platform.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/microfrontend-platform.spec.ts
@@ -13,234 +13,265 @@ import {MicrofrontendPlatformHost} from './host/microfrontend-platform-host';
 import {MicrofrontendPlatformClient} from './client/microfrontend-platform-client';
 import {waitFor} from './testing/spec.util.spec';
 import {PlatformState} from './platform-state';
-import {Beans} from '@scion/toolkit/bean-manager';
+import {Beans, PreDestroy} from '@scion/toolkit/bean-manager';
 import {PlatformPropertyService} from './platform-property-service';
 
 describe('MicrofrontendPlatform', () => {
 
-  beforeEach(async () => await MicrofrontendPlatform.destroy());
-  afterEach(async () => await MicrofrontendPlatform.destroy());
+  describe('Start', () => {
+    beforeEach(() => MicrofrontendPlatform.destroy());
+    afterEach(() => MicrofrontendPlatform.destroy());
 
-  it('should report that the app is not connected to the platform host when the host platform is not found', async () => {
-    const startup = MicrofrontendPlatformClient.connect('client-app', {brokerDiscoverTimeout: 250});
-    await expectAsync(startup).toBeRejected();
-    expect(await MicrofrontendPlatformClient.isConnected()).toBeFalse();
-  });
+    it('should report that the app is not connected to the platform host when the host platform is not found', async () => {
+      const startup = MicrofrontendPlatformClient.connect('client-app', {brokerDiscoverTimeout: 250});
+      await expectAsync(startup).toBeRejected();
+      expect(await MicrofrontendPlatformClient.isConnected()).toBeFalse();
+    });
 
-  it('should report that the app is not connected to the platform host when the client platform is not started', async () => {
-    expect(await MicrofrontendPlatformClient.isConnected()).toBeFalse();
-  });
+    it('should report that the app is not connected to the platform host when the client platform is not started', async () => {
+      expect(await MicrofrontendPlatformClient.isConnected()).toBeFalse();
+    });
 
-  it('should report that the app is connected to the platform host when connected', async () => {
-    await MicrofrontendPlatformHost.start({applications: []});
-    expect(await MicrofrontendPlatformClient.isConnected()).toBeTrue();
-  });
+    it('should report that the app is connected to the platform host when connected', async () => {
+      await MicrofrontendPlatformHost.start({applications: []});
+      expect(await MicrofrontendPlatformClient.isConnected()).toBeTrue();
+    });
 
-  it('should enter state \'started\' when started', async () => {
-    const startup = MicrofrontendPlatformClient.connect('A', {connect: false});
+    it('should enter state \'started\' when started', async () => {
+      const startup = MicrofrontendPlatformClient.connect('A', {connect: false});
 
-    await expectAsync(startup).toBeResolved();
-    expect(MicrofrontendPlatform.state).toEqual(PlatformState.Started);
-  });
+      await expectAsync(startup).toBeResolved();
+      expect(MicrofrontendPlatform.state).toEqual(PlatformState.Started);
+    });
 
-  it('should reject starting the client platform multiple times', async () => {
-    const connect = MicrofrontendPlatformClient.connect('A', {connect: false});
-    await expectAsync(connect).toBeResolved();
-    // Connect to the host again
-    await expectAsync(MicrofrontendPlatformClient.connect('A')).toBeRejectedWithError(/\[MicrofrontendPlatformStartupError] Platform already started/);
-  });
+    it('should reject starting the client platform multiple times', async () => {
+      const connect = MicrofrontendPlatformClient.connect('A', {connect: false});
+      await expectAsync(connect).toBeResolved();
+      // Connect to the host again
+      await expectAsync(MicrofrontendPlatformClient.connect('A')).toBeRejectedWithError(/\[MicrofrontendPlatformStartupError] Platform already started/);
+    });
 
-  it('should reject starting the host platform multiple times', async () => {
-    const startup = MicrofrontendPlatformHost.start({applications: []});
-    await expectAsync(startup).toBeResolved();
-    // Start the platform again
-    await expectAsync(MicrofrontendPlatformHost.start({applications: []})).toBeRejectedWithError(/\[MicrofrontendPlatformStartupError] Platform already started/);
-  });
+    it('should reject starting the host platform multiple times', async () => {
+      const startup = MicrofrontendPlatformHost.start({applications: []});
+      await expectAsync(startup).toBeResolved();
+      // Start the platform again
+      await expectAsync(MicrofrontendPlatformHost.start({applications: []})).toBeRejectedWithError(/\[MicrofrontendPlatformStartupError] Platform already started/);
+    });
 
-  it('should construct eager beans at platform startup', async () => {
-    let constructed = false;
+    it('should construct eager beans at platform startup', async () => {
+      let constructed = false;
 
-    class Bean {
-      constructor() {
-        constructed = true;
+      class Bean {
+        constructor() {
+          constructed = true;
+        }
       }
-    }
 
-    await MicrofrontendPlatform.startPlatform(() => {
-      Beans.register(Bean, {eager: true});
+      await MicrofrontendPlatform.startPlatform(() => {
+        Beans.register(Bean, {eager: true});
+      });
+
+      expect(constructed).toBeTrue();
     });
 
-    expect(constructed).toBeTrue();
-  });
+    it('should construct eager beans in runlevel 1', async () => {
+      const log: string[] = [];
 
-  it('should construct eager beans in runlevel 1', async () => {
-    const log: string[] = [];
-
-    class Bean {
-      constructor() {
-        log.push('constructing eager bean');
+      class Bean {
+        constructor() {
+          log.push('constructing eager bean');
+        }
       }
-    }
 
-    Beans.registerInitializer({
-      useFunction: async () => {
-        log.push('executing initializer [runlevel=0]');
-      }, runlevel: 0,
-    });
-    Beans.registerInitializer({
-      useFunction: async () => {
-        log.push('executing initializer [runlevel=2]');
-      }, runlevel: 2,
+      Beans.registerInitializer({
+        useFunction: async () => {
+          log.push('executing initializer [runlevel=0]');
+        }, runlevel: 0,
+      });
+      Beans.registerInitializer({
+        useFunction: async () => {
+          log.push('executing initializer [runlevel=2]');
+        }, runlevel: 2,
+      });
+
+      await MicrofrontendPlatform.startPlatform(() => {
+        Beans.register(Bean, {eager: true});
+      });
+
+      expect(log).toEqual([
+        'executing initializer [runlevel=0]',
+        'constructing eager bean',
+        'executing initializer [runlevel=2]',
+      ]);
     });
 
-    await MicrofrontendPlatform.startPlatform(() => {
+    it('should wait for initializers to complete before resolving the platform\'s startup promise', async () => {
+      jasmine.clock().install();
+
+      const log: string[] = [];
+
+      Beans.registerInitializer({
+        useFunction: async () => {
+          await waitFor(5000);
+          log.push('initializer 5s');
+        },
+      });
+
+      Beans.registerInitializer({
+        useFunction: async () => {
+          await waitFor(2000);
+          log.push('initializer 2s');
+        },
+      });
+
+      Beans.registerInitializer({
+        useFunction: async () => {
+          await waitFor(8000);
+          log.push('initializer 8s');
+        },
+      });
+
+      Beans.registerInitializer({
+        useFunction: async () => {
+          await waitFor(6000);
+          log.push('initializer 6s');
+        },
+      });
+
+      Beans.registerInitializer({
+        useFunction: async () => {
+          await waitFor(1000);
+          log.push('initializer 1s [runlevel 5]');
+        },
+        runlevel: 5,
+      });
+
+      let started = false;
+      void MicrofrontendPlatform.startPlatform().then(() => {
+        started = true;
+      });
+      await drainMicrotaskQueue(100);
+
+      // after 1s
+      jasmine.clock().tick(1000);
+      await drainMicrotaskQueue(100);
+      expect(log).toEqual([]);
+      expect(started).toBeFalse();
+
+      // after 2s
+      jasmine.clock().tick(1000);
+      await drainMicrotaskQueue(100);
+      expect(log).toEqual(['initializer 2s']);
+      expect(started).toBeFalse();
+
+      // after 3s
+      jasmine.clock().tick(1000);
+      await drainMicrotaskQueue(100);
+      expect(log).toEqual(['initializer 2s']);
+      expect(started).toBeFalse();
+
+      // after 4s
+      jasmine.clock().tick(1000);
+      await drainMicrotaskQueue(100);
+      expect(log).toEqual(['initializer 2s']);
+      expect(started).toBeFalse();
+
+      // after 5s
+      jasmine.clock().tick(1000);
+      await drainMicrotaskQueue(100);
+      expect(log).toEqual(['initializer 2s', 'initializer 5s']);
+      expect(started).toBeFalse();
+
+      // after 6s
+      jasmine.clock().tick(1000);
+      await drainMicrotaskQueue(100);
+      expect(log).toEqual(['initializer 2s', 'initializer 5s', 'initializer 6s']);
+      expect(started).toBeFalse();
+
+      // after 7s
+      jasmine.clock().tick(1000);
+      await drainMicrotaskQueue(100);
+      expect(log).toEqual(['initializer 2s', 'initializer 5s', 'initializer 6s']);
+      expect(started).toBeFalse();
+
+      // after 8s
+      jasmine.clock().tick(1000);
+      await drainMicrotaskQueue(100);
+      expect(log).toEqual(['initializer 2s', 'initializer 5s', 'initializer 6s', 'initializer 8s']);
+      expect(started).toBeFalse();
+
+      // after 9s
+      jasmine.clock().tick(1000);
+      await drainMicrotaskQueue(100);
+      expect(log).toEqual(['initializer 2s', 'initializer 5s', 'initializer 6s', 'initializer 8s', 'initializer 1s [runlevel 5]']);
+
+      // assert the platform to be started
+      expect(started).toBeTrue();
+
+      jasmine.clock().uninstall();
+    });
+
+    it('should resolve the \'start\' Promise when all initializers resolve', async () => {
+      Beans.registerInitializer(() => Promise.resolve());
+      Beans.registerInitializer(() => Promise.resolve());
+      Beans.registerInitializer(() => Promise.resolve());
+
+      await expectAsync(MicrofrontendPlatform.startPlatform()).toBeResolved();
+    });
+
+    it('should reject the \'start\' Promise when an initializer rejects', async () => {
+      Beans.registerInitializer(() => Promise.resolve());
+      Beans.registerInitializer(() => Promise.reject(Error()));
+      Beans.registerInitializer(() => Promise.resolve());
+
+      await expectAsync(MicrofrontendPlatform.startPlatform()).toBeRejectedWithError(/MicrofrontendPlatformStartupError/);
+    });
+
+    it('should allow looking up platform properties from the host', async () => {
+      await MicrofrontendPlatformHost.start({
+        applications: [],
+        properties: {
+          'prop1': 'PROP1',
+          'prop2': 'PROP2',
+          'prop3': 'PROP3',
+        },
+      });
+
+      expect(Beans.get(PlatformPropertyService).properties()).toEqual(new Map()
+        .set('prop1', 'PROP1')
+        .set('prop2', 'PROP2')
+        .set('prop3', 'PROP3'),
+      );
+    });
+  });
+
+  describe('Destroy', () => {
+    it('should shutdown platform synchronously', async () => {
+      // GIVEN
+      const log: string[] = [];
+
+      class Bean implements PreDestroy {
+        public preDestroy(): void {
+          log.push(`bean destroyed [state=${MicrofrontendPlatform.state}]`);
+        }
+      }
+
       Beans.register(Bean, {eager: true});
+
+      await MicrofrontendPlatform.startPlatform();
+      MicrofrontendPlatform.onState(PlatformState.Stopping, () => log.push(`microfrontend stopping [state=${MicrofrontendPlatform.state}]`));
+      MicrofrontendPlatform.onState(PlatformState.Stopped, () => log.push(`microfrontend stopped [state=${MicrofrontendPlatform.state}]`));
+
+      // WHEN
+      MicrofrontendPlatform.destroy();
+
+      // THEN
+      expect(log).toEqual([
+        `microfrontend stopping [state=${PlatformState.Stopping}]`,
+        `bean destroyed [state=${PlatformState.Stopping}]`,
+        `microfrontend stopped [state=${PlatformState.Stopped}]`,
+      ]);
     });
-
-    expect(log).toEqual([
-      'executing initializer [runlevel=0]',
-      'constructing eager bean',
-      'executing initializer [runlevel=2]',
-    ]);
-  });
-
-  it('should wait for initializers to complete before resolving the platform\'s startup promise', async () => {
-    jasmine.clock().install();
-
-    const log: string[] = [];
-
-    Beans.registerInitializer({
-      useFunction: async () => {
-        await waitFor(5000);
-        log.push('initializer 5s');
-      },
-    });
-
-    Beans.registerInitializer({
-      useFunction: async () => {
-        await waitFor(2000);
-        log.push('initializer 2s');
-      },
-    });
-
-    Beans.registerInitializer({
-      useFunction: async () => {
-        await waitFor(8000);
-        log.push('initializer 8s');
-      },
-    });
-
-    Beans.registerInitializer({
-      useFunction: async () => {
-        await waitFor(6000);
-        log.push('initializer 6s');
-      },
-    });
-
-    Beans.registerInitializer({
-      useFunction: async () => {
-        await waitFor(1000);
-        log.push('initializer 1s [runlevel 5]');
-      },
-      runlevel: 5,
-    });
-
-    let started = false;
-    void MicrofrontendPlatform.startPlatform().then(() => {
-      started = true;
-    });
-    await drainMicrotaskQueue(100);
-
-    // after 1s
-    jasmine.clock().tick(1000);
-    await drainMicrotaskQueue(100);
-    expect(log).toEqual([]);
-    expect(started).toBeFalse();
-
-    // after 2s
-    jasmine.clock().tick(1000);
-    await drainMicrotaskQueue(100);
-    expect(log).toEqual(['initializer 2s']);
-    expect(started).toBeFalse();
-
-    // after 3s
-    jasmine.clock().tick(1000);
-    await drainMicrotaskQueue(100);
-    expect(log).toEqual(['initializer 2s']);
-    expect(started).toBeFalse();
-
-    // after 4s
-    jasmine.clock().tick(1000);
-    await drainMicrotaskQueue(100);
-    expect(log).toEqual(['initializer 2s']);
-    expect(started).toBeFalse();
-
-    // after 5s
-    jasmine.clock().tick(1000);
-    await drainMicrotaskQueue(100);
-    expect(log).toEqual(['initializer 2s', 'initializer 5s']);
-    expect(started).toBeFalse();
-
-    // after 6s
-    jasmine.clock().tick(1000);
-    await drainMicrotaskQueue(100);
-    expect(log).toEqual(['initializer 2s', 'initializer 5s', 'initializer 6s']);
-    expect(started).toBeFalse();
-
-    // after 7s
-    jasmine.clock().tick(1000);
-    await drainMicrotaskQueue(100);
-    expect(log).toEqual(['initializer 2s', 'initializer 5s', 'initializer 6s']);
-    expect(started).toBeFalse();
-
-    // after 8s
-    jasmine.clock().tick(1000);
-    await drainMicrotaskQueue(100);
-    expect(log).toEqual(['initializer 2s', 'initializer 5s', 'initializer 6s', 'initializer 8s']);
-    expect(started).toBeFalse();
-
-    // after 9s
-    jasmine.clock().tick(1000);
-    await drainMicrotaskQueue(100);
-    expect(log).toEqual(['initializer 2s', 'initializer 5s', 'initializer 6s', 'initializer 8s', 'initializer 1s [runlevel 5]']);
-
-    // assert the platform to be started
-    expect(started).toBeTrue();
-
-    jasmine.clock().uninstall();
-  });
-
-  it('should resolve the \'start\' Promise when all initializers resolve', async () => {
-    Beans.registerInitializer(() => Promise.resolve());
-    Beans.registerInitializer(() => Promise.resolve());
-    Beans.registerInitializer(() => Promise.resolve());
-
-    await expectAsync(MicrofrontendPlatform.startPlatform()).toBeResolved();
-  });
-
-  it('should reject the \'start\' Promise when an initializer rejects', async () => {
-    Beans.registerInitializer(() => Promise.resolve());
-    Beans.registerInitializer(() => Promise.reject(Error()));
-    Beans.registerInitializer(() => Promise.resolve());
-
-    await expectAsync(MicrofrontendPlatform.startPlatform()).toBeRejectedWithError(/MicrofrontendPlatformStartupError/);
-  });
-
-  it('should allow looking up platform properties from the host', async () => {
-    await MicrofrontendPlatformHost.start({
-      applications: [],
-      properties: {
-        'prop1': 'PROP1',
-        'prop2': 'PROP2',
-        'prop3': 'PROP3',
-      },
-    });
-
-    expect(Beans.get(PlatformPropertyService).properties()).toEqual(new Map()
-      .set('prop1', 'PROP1')
-      .set('prop2', 'PROP2')
-      .set('prop3', 'PROP3'),
-    );
   });
 });
 

--- a/projects/scion/microfrontend-platform/src/lib/microfrontend-platform.ts
+++ b/projects/scion/microfrontend-platform/src/lib/microfrontend-platform.ts
@@ -98,12 +98,12 @@ export class MicrofrontendPlatform {
 
     try {
       startupFn?.();
-      await this.enterState(PlatformState.Starting);
+      this.enterState(PlatformState.Starting);
       await Beans.start({eagerBeanConstructRunlevel: Runlevel.One, initializerDefaultRunlevel: Runlevel.Two});
-      await this.enterState(PlatformState.Started);
+      this.enterState(PlatformState.Started);
     }
     catch (error) {
-      await this.destroy();
+      this.destroy();
       throw Error(`[MicrofrontendPlatformStartupError] Microfrontend platform failed to start: ${error}`, {cause: error});
     }
   }
@@ -113,10 +113,10 @@ export class MicrofrontendPlatform {
    *
    * @return a Promise that resolves once the platformed stopped.
    */
-  public static async destroy(): Promise<void> {
-    await this.enterState(PlatformState.Stopping);
+  public static destroy(): void {
+    this.enterState(PlatformState.Stopping);
     Beans.destroy();
-    await this.enterState(PlatformState.Stopped);
+    this.enterState(PlatformState.Stopped);
   }
 
   /**
@@ -136,34 +136,31 @@ export class MicrofrontendPlatform {
   }
 
   /**
-   * Waits for the platform to enter the specified {@link PlatformState}.
-   * If already in that state, the Promise resolves instantly.
+   * Registers a callback function to be executed when the platform enters the specified {@link PlatformState}.
+   * If already in that state, the callback is executed immediately.
+   * To ensure that the provided cleanup logic is executed before the browser unloads the page,
+   * the callback function registered on the {@link PlatformState.Stopping} or {@link PlatformState.Stopped} state must be synchronous.
    *
    * @param  state - the state to wait for.
-   * @return A Promise that resolves when the platform enters the given state.
-   *         If already in that state, the Promise resolves instantly.
+   * @param  callbackFn - callback function to be executed.
    */
-  public static async whenState(state: PlatformState): Promise<void> {
-    return new Promise<void>((resolve, reject) => {
-      this._state$
-        .pipe(first(it => it === state))
-        .subscribe({
-          error: reject,
-          complete: resolve,
-        });
-    });
+  public static onState(state: PlatformState.Stopping | PlatformState.Stopped, callbackFn: () => void): void;
+  public static onState(state: PlatformState.Starting | PlatformState.Started, callbackFn: () => void | Promise<void>): void;
+  public static onState(state: PlatformState, callbackFn: () => void | Promise<void>): void {
+    this._state$
+      .pipe(first(it => it === state))
+      .subscribe(() => {
+        void callbackFn();
+      });
   }
 
-  private static async enterState(newState: PlatformState): Promise<void> {
+  private static enterState(newState: PlatformState): void {
     const currentState = (this.state === PlatformState.Stopped) ? -1 : this.state;
     if (currentState >= newState) {
       throw Error(`[PlatformStateError] Failed to enter platform state [prevState=${PlatformState[this.state]}, newState=${PlatformState[newState]}].`);
     }
 
     this._state$.next(newState);
-
-    // Let microtasks waiting for entering that state to resolve first.
-    await this.whenState(newState);
   }
 }
 

--- a/projects/scion/microfrontend-platform/src/lib/microfrontend-platform.ts
+++ b/projects/scion/microfrontend-platform/src/lib/microfrontend-platform.ts
@@ -98,25 +98,23 @@ export class MicrofrontendPlatform {
 
     try {
       startupFn?.();
-      await this.enterState(PlatformState.Starting);
+      this.enterState(PlatformState.Starting);
       await Beans.start({eagerBeanConstructRunlevel: Runlevel.One, initializerDefaultRunlevel: Runlevel.Two});
-      await this.enterState(PlatformState.Started);
+      this.enterState(PlatformState.Started);
     }
     catch (error) {
-      await this.destroy();
+      this.destroy();
       throw Error(`[MicrofrontendPlatformStartupError] Microfrontend platform failed to start: ${error}`, {cause: error});
     }
   }
 
   /**
    * Destroys this platform and releases resources allocated.
-   *
-   * @return a Promise that resolves once the platformed stopped.
    */
-  public static async destroy(): Promise<void> {
-    await this.enterState(PlatformState.Stopping);
+  public static destroy(): void {
+    this.enterState(PlatformState.Stopping);
     Beans.destroy();
-    await this.enterState(PlatformState.Stopped);
+    this.enterState(PlatformState.Stopped);
   }
 
   /**
@@ -136,34 +134,33 @@ export class MicrofrontendPlatform {
   }
 
   /**
-   * Waits for the platform to enter the specified {@link PlatformState}.
-   * If already in that state, the Promise resolves instantly.
+   * Registers a callback function to be executed when the platform enters the specified {@link PlatformState}.
+   * If already in that state, the callback is executed immediately.
+   *
+   * If the provided callback function returns a promise, that promise is not awaited.
+   * To ensure that the provided cleanup logic is executed before the browser unloads the page,
+   * the callback function registered with the {@link PlatformState.Stopping} or {@link PlatformState.Stopped} state must be synchronous.
    *
    * @param  state - the state to wait for.
-   * @return A Promise that resolves when the platform enters the given state.
-   *         If already in that state, the Promise resolves instantly.
+   * @param  callbackFn - callback function to be executed.
    */
-  public static async whenState(state: PlatformState): Promise<void> {
-    return new Promise<void>((resolve, reject) => {
-      this._state$
-        .pipe(first(it => it === state))
-        .subscribe({
-          error: reject,
-          complete: resolve,
-        });
-    });
+  public static onState(state: PlatformState.Starting | PlatformState.Started, callbackFn: () => void | Promise<void>): void;
+  public static onState(state: PlatformState.Stopping | PlatformState.Stopped, callbackFn: () => void): void;
+  public static onState(state: PlatformState, callbackFn: () => void | Promise<void>): void {
+    this._state$
+      .pipe(first(it => it === state))
+      .subscribe(() => {
+        void callbackFn();
+      });
   }
 
-  private static async enterState(newState: PlatformState): Promise<void> {
+  private static enterState(newState: PlatformState): void {
     const currentState = (this.state === PlatformState.Stopped) ? -1 : this.state;
     if (currentState >= newState) {
       throw Error(`[PlatformStateError] Failed to enter platform state [prevState=${PlatformState[this.state]}, newState=${PlatformState[newState]}].`);
     }
 
     this._state$.next(newState);
-
-    // Let microtasks waiting for entering that state to resolve first.
-    await this.whenState(newState);
   }
 }
 

--- a/projects/scion/microfrontend-platform/src/lib/topic-matcher.util.ts
+++ b/projects/scion/microfrontend-platform/src/lib/topic-matcher.util.ts
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import {Arrays} from '@scion/toolkit/util';
+import {Objects} from '@scion/toolkit/util';
 import {Topics} from './topics.util';
 
 /**
@@ -58,7 +58,7 @@ export class TopicMatcher {
     if (patternSegments.length !== inputTopicSegments.length) {
       return {matches: false};
     }
-    if (Arrays.isEqual(inputTopicSegments, patternSegments, {exactOrder: true})) {
+    if (Objects.isEqual(inputTopicSegments, patternSegments)) {
       return {matches: true, params: new Map()};
     }
     if (!patternSegments.some(Topics.isWildcardSegment)) {

--- a/projects/scion/microfrontend-platform/src/lib/version.spec.ts
+++ b/projects/scion/microfrontend-platform/src/lib/version.spec.ts
@@ -20,13 +20,13 @@ describe('MicrofrontendPlatform', () => {
 
   const disposables = new Set<Disposable>();
 
-  beforeEach(async () => {
-    await MicrofrontendPlatform.destroy();
+  beforeEach(() => {
+    MicrofrontendPlatform.destroy();
     installLoggerSpies();
   });
 
-  afterEach(async () => {
-    await MicrofrontendPlatform.destroy();
+  afterEach(() => {
+    MicrofrontendPlatform.destroy();
     disposables.forEach(disposable => disposable());
   });
 


### PR DESCRIPTION
The `unload` event has been deprecated and browsers will prevent handlers from firing. The most reliable event for initiating platform shutdown is the `pagehide` event, when the page is entering the terminated state. To ensure that client applications can reliably send messages to the host application during shutdown, the platform now stops synchronously.

BREAKING CHANGE: The synchronous shutdown untroduces an API breakings change for host and client applications.
To migrate:
- `MicrofrontendPlatform.destroy` now returns `void` instead of `Promise`.
- `MicrofrontendPlatform.whenState` has been renamed to `MicrofrontendPlatform.onState`. It now accepts a callback function as its second argument instead of returning a `Promise`.
  
  **Example**
  ```ts
  // Before Migration
  MicrofrontendPlatform.whenState(PlatformState.Starting).then(() => {
    // invoked when the platform is about to start.
  });

  // After Migration
  MicrofrontendPlatform.onState(PlatformState.Starting, () => {
    // invoked when the platform is about to start.
  });
  ```

closes #372